### PR TITLE
(maint) Add a packaging process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage/
 log/
 .DS_Store
 tmp/
+output/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,137 @@
+# Change Log
+
+All notable changes to the "puppet-editor-services" repository will be documented in this file.
+
+Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+
+## Unreleased
+
+## 0.10.0 - 2018-03-29
+
+- ([GH-218](https://github.com/jpogran/puppet-vscode/issues/218)) Validate EPP files
+- ([GH-244](https://github.com/jpogran/puppet-vscode/issues/244)) Update puppet-lint to 2.3.5
+- ([GH-245](https://github.com/jpogran/puppet-vscode/issues/245)) Update puppet-lint to 2.3.5
+- ([GH-216](https://github.com/jpogran/puppet-vscode/issues/216)) Better syntax highlighting
+- ([GH-214](https://github.com/jpogran/puppet-vscode/issues/214)) Updated readme for pdk 1.3.X
+- ([GH-225](https://github.com/jpogran/puppet-vscode/issues/225)) Readd Local Workspace comand line option
+- ([GH-231](https://github.com/jpogran/puppet-vscode/issues/231)) Make Document Validation asynchronous
+- ([GH-236](https://github.com/jpogran/puppet-vscode/issues/236)) Remove the preload option
+- ([GH-236](https://github.com/jpogran/puppet-vscode/issues/236)) Add experimental file cache option
+
+## 0.9.0 - 2018-02-01
+
+- ([GH-50](https://github.com/jpogran/puppet-vscode/issues/50)) Add document formatter for puppet-lint
+- ([GH-204](https://github.com/jpogran/puppet-vscode/issues/204)) Fix debug server for Puppet 4.x
+
+## 0.8.0 - 2017-11-24
+
+- ([GH-180](https://github.com/jpogran/puppet-vscode/issues/180)) Backslashes in File Path do not display in Node Graph
+- ([GH-100](https://github.com/jpogran/puppet-vscode/issues/100)) Experimental Puppet-Debugger
+- ([PR-194](https://github.com/jpogran/puppet-vscode/pull/194)) Fix logger in PDK New Task
+- ([PR-195](https://github.com/jpogran/puppet-vscode/pull/195)) Do not error in validation exception handler
+- ([GH-187](https://github.com/jpogran/puppet-vscode/issues/187)) Add stdio mode to language server
+- (maint) Fix rubocop violations
+
+## 0.7.2 - 2017-11-01
+
+- ([GH-165](https://github.com/jpogran/puppet-vscode/issues/165)) Broken readme link
+- ([GH-88](https://github.com/jpogran/puppet-vscode/issues/88))  Rework Node Graph Preview to use local svg
+- ([GH-154](https://github.com/jpogran/puppet-vscode/issues/154)) Use hosted JSON schema files
+- ([GH-169](https://github.com/jpogran/puppet-vscode/issues/169)) Fix bug in sytanx highlighting
+- ([GH-167](https://github.com/jpogran/puppet-vscode/issues/167)) Add PDK New Task command
+- ([GH-156](https://github.com/jpogran/puppet-vscode/issues/156)) Document restarting Puppet extension command
+- ([GH-177](https://github.com/jpogran/puppet-vscode/issues/177)) Remove detection of Puppet VERSION file
+- ([GH-175](https://github.com/jpogran/puppet-vscode/issues/175)) Fix 'could not find valid version of Puppet'
+
+## 0.7.1 - 2017-09-29
+
+- ([GH-157](https://github.com/jpogran/puppet-vscode/issues/157)) Puppet Resource command hidden
+
+## 0.7.0 - 2017-09-22
+
+- ([GH-115](https://github.com/jpogran/puppet-vscode/issues/115)) Add Puppet Development Kit (PDK) integration
+- ([GH-136](https://github.com/jpogran/puppet-vscode/issues/136)) Create a better UI experience while Puppet loads
+- ([GH-61](https://github.com/jpogran/puppet-vscode/issues/61))  Create a better experience when language client fails
+- ([GH-135](https://github.com/jpogran/puppet-vscode/issues/135)) Fix incorrect logger when a client error occurs
+- ([GH-129](https://github.com/jpogran/puppet-vscode/issues/129)) Honor inline puppet lint directives
+- ([GH-133](https://github.com/jpogran/puppet-vscode/issues/133)) Fix issue with puppet 5.1.0
+- ([GH-122](https://github.com/jpogran/puppet-vscode/issues/122)) Show upgrade message with changelog
+- ([GH-120](https://github.com/jpogran/puppet-vscode/issues/120)) Allow custom Puppet agent installation directory
+- ([GH-126](https://github.com/jpogran/puppet-vscode/issues/126)) Fix completion provider with Puppet 5.2.0
+- ([GH-110](https://github.com/jpogran/puppet-vscode/issues/110)) Add extension analytics
+- ([GH-138](https://github.com/jpogran/puppet-vscode/issues/138)) Set extension analytics to prod
+- ([GH-109](https://github.com/jpogran/puppet-vscode/issues/109)) Randomize languageserver port
+- ([GH-111](https://github.com/jpogran/puppet-vscode/issues/111)) Parse puppet-lint.rc in module directory
+
+## 0.6.0 - 2017-08-08
+
+- Fix packaging error where language server was not included
+
+## 0.5.3 - 2017-08-08
+
+- ([GH-92](https://github.com/jpogran/puppet-vscode/issues/92)) Added context menus for Puppet Resource and Nodegraph preview
+- ([GH-98](https://github.com/jpogran/puppet-vscode/issues/98)) Improve language server function and type loading
+- ([GH-52](https://github.com/jpogran/puppet-vscode/issues/52)) JSON validation and schema for metadata.json
+- ([GH-47](https://github.com/jpogran/puppet-vscode/issues/47)) Fixes pending language server tests
+- ([GH-45](https://github.com/jpogran/puppet-vscode/issues/45)) Fix runocop violations for language tcp server
+- ([GH-89](https://github.com/jpogran/puppet-vscode/issues/89)) Document support for linux in readme
+- ([GH-64](https://github.com/jpogran/puppet-vscode/issues/64)) Additional language server tests
+- ([GH-103](https://github.com/jpogran/puppet-vscode/issues/103)) Extension now supports puppet-lint rc files
+- ([GH-99](https://github.com/jpogran/puppet-vscode/issues/99)) Improved client README and Gallery page
+
+## 0.4.6 - 2017-06-29
+
+### Changed
+
+- Updated links in README
+- Added more information to package manifest
+- Minor updates to README
+
+## 0.4.5 - 2017-06-27
+
+### Changed
+
+- Updated badge link location in README
+
+## 0.4.2 - 2017-06-27
+
+### Changed
+
+- Updated badge links to use proper extension id
+
+## 0.4.0 - 2017-06-27
+
+### Added
+
+- A functional Language Server for the Puppet language
+  - Real time puppet lint
+  - Auto-complete and Hover support for many puppet language facets
+  - Auto-complete and Hover support for facts
+  - 'puppet resource' support
+  - Preview node graph support
+- Tested on older Puppet versions (4.7 LTS series)
+- Added testing on Travis and Appveyor
+
+### Fixed
+
+- Completion and Hover provider didn't load puppet modules
+- Implemented textDocument/didClose notification
+- Fixed completion at file beginning on new lines and on keywords
+
+## 0.0.3 - 2017-05-08
+
+### Added
+
+- Puppet Parser validate linter added
+
+## 0.0.2 - 2017-05-04
+
+### Added
+
+- Puppet Resource and Puppet Module commands.
+
+## 0.0.1 - 2017-04-10
+
+### Added
+
+- Initial release of the puppet extension.

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,10 @@ group :development do
   gem "win32-process", "<= 0.7.5",  :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
   gem "win32-security", "<= 0.2.5", :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
   gem "win32-service", "<= 0.8.8",  :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
+
+  # Gems for building release tarballs etc.
+  gem "archive-zip", :require => false
+  gem "minitar"    , :require => false
 end
 
 # Evaluate Gemfile.local if it exists

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,6 +42,11 @@ environment:
     RUBY_VER: 23-x64
     RAKE_TASK: rubocop
 
+  # Build release archives
+  - PUPPET_GEM_VERSION: "~> 4.0"
+    RUBY_VER: 23-x64
+    RAKE_TASK: build
+
 matrix:
   fast_finish: true
 
@@ -70,3 +75,6 @@ build: off
 
 test_script:
 - cmd: IF NOT [%RAKE_TASK%] == [] bundle exec rake %RAKE_TASK%
+
+artifacts:
+  - path: output/*.*

--- a/tools/upload_release.ps1
+++ b/tools/upload_release.ps1
@@ -1,0 +1,148 @@
+param(
+  [parameter(Mandatory=$true)]
+  [String]$ReleaseVersion,
+
+  [parameter(Mandatory=$true)]
+  [String]$GitHubUsername,
+
+  [parameter(Mandatory=$true)]
+  [String]$GitHubToken
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Adapted from https://www.herebedragons.io/powershell-create-github-release-with-artifact
+function Update-GitHubRelease($versionNumber, $preRelease, $releaseNotes, $artifactOutputDirectory, $gitHubUsername, $gitHubRepository, $gitHubApiUsername, $gitHubApiKey)
+{
+  $draft = $false
+
+  $auth = 'Basic ' + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes($gitHubApiUsername + ':' + $gitHubApiKey));
+
+  # Github uses TLS 1.2
+  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+  # Find existing release
+  $ReleaseDetails = $null
+  $releaseParams = @{
+    Uri = "https://api.github.com/repos/$gitHubUsername/$gitHubRepository/releases/tags/$versionNumber";
+    Method = 'GET';
+    Headers = @{
+      Authorization = $auth;
+    }
+    ContentType = 'application/json';
+  }
+  try {
+    $ReleaseDetails = Invoke-RestMethod @releaseParams
+  }
+  catch {
+    # Release is missing, create it
+    $ReleaseDetails = $null
+  }
+
+  if ($ReleaseDetails -eq $null) {
+    Write-Host "Creating release $versionNumber"
+    # Create a release
+    $releaseData = @{
+      tag_name = [string]::Format("{0}", $versionNumber);
+      name = [string]::Format("{0}", $versionNumber);
+      body = $releaseNotes;
+      draft = $draft;
+      prerelease = $preRelease;
+    }
+    $releaseParams = @{
+      ContentType = 'application/json'
+      Uri = "https://api.github.com/repos/$gitHubUsername/$gitHubRepository/releases";
+      Method = 'POST';
+      Headers = @{
+        Authorization = $auth;
+      }
+      Body = (ConvertTo-Json $releaseData -Compress)
+    }
+    $ReleaseDetails = Invoke-RestMethod @releaseParams
+  } else {
+    Write-Host "Updating release $versionNumber"
+    # Create a release
+    $releaseData = @{
+      tag_name = [string]::Format("{0}", $versionNumber);
+      name = [string]::Format("{0}", $versionNumber);
+      body = $releaseNotes;
+      draft = $draft;
+      prerelease = $preRelease;
+    }
+    $releaseParams = @{
+      ContentType = 'application/json'
+      Uri = "https://api.github.com/repos/$gitHubUsername/$gitHubRepository/releases/$($ReleaseDetails.id)";
+      Method = 'PATCH';
+      Headers = @{
+        Authorization = $auth;
+      }
+      Body = (ConvertTo-Json $releaseData -Compress)
+    }
+    $ReleaseDetails = Invoke-RestMethod @releaseParams
+  }
+
+  # Upload assets
+  $uploadUri = $ReleaseDetails | Select -ExpandProperty upload_url
+  $uploadUri = $uploadUri -creplace '\{\?name,label\}'
+
+  Get-ChildItem -Path $artifactOutputDirectory | % {
+    $filename = $_.Name
+    $filepath = $_.Fullname
+    Write-Host "Uploading $filename ..."
+
+    $uploadParams = @{
+      Uri = $uploadUri;
+      Method = 'POST';
+      Headers = @{
+        Authorization = $auth;
+      }
+      ContentType = 'application/text';
+      InFile = $filepath
+    }
+
+    if ($filename -match '\.zip$') {
+      $uploadParams.ContentType = 'application/zip'
+    }
+    if ($filename -match '\.gz$') {
+      $uploadParams.ContentType = 'application/tar+gzip'
+    }
+    $uploadParams.Uri += "?name=$filename"
+
+    Invoke-RestMethod @uploadParams | Out-Null
+  }
+}
+
+function Get-ReleaseNotes($Version) {
+  Write-Host "Getting release notes for version $Version ..."
+
+  $changelog = Join-Path -Path $PSScriptRoot -ChildPath '..\CHANGELOG.md'
+
+  $releaseNotes = $null
+  $inSection = $false
+  Get-Content $changelog | % {
+    $line = $_
+
+    if ($inSection) {
+      if ($line -match "^## ") {
+        $inSection = $false
+      } else {
+        $releaseNotes = $releaseNotes + "`n" + $line
+      }
+    } else {
+      if ($line -match "^## ${version} ") {
+        $releaseNotes = $line
+        $inSection = $true
+      }
+    }
+  }
+  return $releaseNotes
+}
+
+Update-GitHubRelease -versionNumber $releaseVersion `
+               -preRelease $false `
+               -releaseNotes (Get-ReleaseNotes -Version $releaseVersion) `
+               -artifactOutputDirectory 'output' `
+               -gitHubUsername 'lingua-pupuli' `
+               -gitHubRepository 'puppet-editor-services' `
+               -gitHubApiUsername $GitHubUsername `
+               -gitHubApiKey $GitHubToken


### PR DESCRIPTION
Previously the language server resided in the same repo as the VS Code client
which meant a discrete packaging server was not required.  As this is now a
separate repo, this commit adds a rake build command to create ZIP and Tar files
of the language server.
