### PR TITLE
(GH-11) Refactor transport layer and fix STDIO server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Unreleased
 
-- ([GH-11](https://github.com/lingua-pupuli/puppet-editor-services/issues/11))  Refactor the transport layers to loosen object coupling
+- ([GH-11](https://github.com/lingua-pupuli/puppet-editor-services/issues/11)) Refactor the transport layers to loosen object coupling
+- ([GH-11](https://github.com/lingua-pupuli/puppet-editor-services/issues/11)) Fix STDIO server
 
 ## 0.10.0 - 2018-03-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 - ([GH-11](https://github.com/lingua-pupuli/puppet-editor-services/issues/11)) Refactor the transport layers to loosen object coupling
 - ([GH-11](https://github.com/lingua-pupuli/puppet-editor-services/issues/11)) Fix STDIO server
+- Stop bad logfile destinations from crashing the language and debug servers
 
 ## 0.10.0 - 2018-03-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Unreleased
 
+- ([GH-11](https://github.com/lingua-pupuli/puppet-editor-services/issues/11))  Refactor the transport layers to loosen object coupling
+
 ## 0.10.0 - 2018-03-29
 
 - ([GH-218](https://github.com/jpogran/puppet-vscode/issues/218)) Validate EPP files

--- a/lib/puppet-debugserver.rb
+++ b/lib/puppet-debugserver.rb
@@ -83,7 +83,7 @@ module PuppetDebugServer
 
     server.add_service(options[:ipaddress], options[:port])
     trap('INT') { server.stop_services(true) }
-    server.start(PuppetDebugServer::MessageRouter, options, 2)
+    server.start(PuppetDebugServer::JSONHandler, options, 2)
 
     log_message(:info, 'Debug Server exited.')
   end

--- a/lib/puppet-editor-services.rb
+++ b/lib/puppet-editor-services.rb
@@ -1,4 +1,4 @@
-%w[logging version simple_tcp_server].each do |lib|
+%w[logging version simple_base simple_tcp_server simple_stdio_server].each do |lib|
   begin
     require "puppet-editor-services/#{lib}"
   rescue LoadError

--- a/lib/puppet-editor-services/logging.rb
+++ b/lib/puppet-editor-services/logging.rb
@@ -16,16 +16,28 @@ module PuppetEditorServices
     else
       @logger.unknown(message)
     end
+    @log_file.fsync unless @log_file.nil?
   end
 
   def self.init_logging(options)
+    @log_file = nil
     if options[:debug].nil?
       @logger = nil
     elsif (options[:debug].casecmp 'stdout').zero?
       @logger = Logger.new($stdout)
     elsif !options[:debug].to_s.empty?
       # Log to file
-      @logger = Logger.new(options[:debug])
+      begin
+        @log_file = File.open(options[:debug], 'w')
+      rescue Errno::ENOENT => e
+        # We can't open the log file and we can't log to STDOUT if we're in STDIO mode
+        # So log the error to STDERR and disable logging
+        $stderr.puts "Error opening log file #{options[:debug]} : #{e}" # rubocop:disable Style/StderrPuts
+        @log_file = nil
+        return
+      end
+      @log_file.sync = true
+      @logger = Logger.new(@log_file)
     end
   end
 end

--- a/lib/puppet-editor-services/simple_base.rb
+++ b/lib/puppet-editor-services/simple_base.rb
@@ -1,0 +1,49 @@
+module PuppetEditorServices
+  class SimpleServerConnectionBase
+    # Override this method
+    # @api public
+    def error?
+      false
+    end
+
+    # Override this method
+    # @api public
+    def send_data(_data)
+      false
+    end
+
+    # Override this method
+    # @api public
+    def close_connection_after_writing
+      true
+    end
+
+    # Override this method
+    # @api public
+    def close_connection
+      true
+    end
+  end
+
+  class SimpleServerConnectionHandler
+    attr_accessor :client_connection
+
+    # Override this method
+    # @api public
+    def receive_data(_data)
+      false
+    end
+
+    # Override this method
+    # @api public
+    def post_init
+      true
+    end
+
+    # Override this method
+    # @api public
+    def unbind
+      true
+    end
+  end
+end

--- a/lib/puppet-editor-services/simple_stdio_server.rb
+++ b/lib/puppet-editor-services/simple_stdio_server.rb
@@ -1,26 +1,91 @@
 module PuppetEditorServices
   class SimpleSTDIOServerConnection < SimpleServerConnectionBase
-    attr_accessor :socket
+    attr_accessor :simple_stdio_server
 
-    def initialize(socket)
-      @socket = socket
+    def initialize(simple_stdio_server)
+      @simple_stdio_server = simple_stdio_server
     end
 
     def send_data(data)
-      return false if socket.nil?
-      socket.write(data)
+      $stdout.write(data)
       true
     end
 
     def close_connection_after_writing
-      socket.flush unless socket.nil?
-      simple_tcp_server.remove_connection_async(socket)
+      $stdout.flush
+      @simple_stdio_server.close_connection
       true
     end
 
     def close_connection
-      simple_tcp_server.remove_connection_async(socket)
+      @simple_stdio_server.close_connection
       true
+    end
+  end
+
+  class SimpleSTDIOServer
+    attr_accessor :exiting
+
+    def log(message)
+      PuppetEditorServices.log_message(:debug, "STDIOSRV: #{message}")
+    end
+
+    def initialize
+      @exiting = false
+    end
+
+    def start(handler_klass = PuppetEditorServices::SimpleTCPServerConnection, connection_options = {})
+      connection_options[:servicename] = 'LANGUAGE SERVER' if connection_options[:servicename].nil?
+      # This is a little heavy handed but we need to suppress writes to STDOUT and STDERR
+      $VERBOSE = nil
+
+      $stdout.sync = true
+      # Stop the stupid CRLF injection when on Windows
+      $stdout.binmode unless $stdout.binmode
+
+      handler = handler_klass.new(connection_options)
+      client_connection = PuppetEditorServices::SimpleSTDIOServerConnection.new(self)
+      handler.client_connection = client_connection
+      handler.post_init
+
+      log('Starting STDIO server...')
+      loop do
+        inbound_data = nil
+        read_from_pipe($stdin, 2) { |data| inbound_data = data }
+        break if @exiting
+        handler.receive_data(inbound_data) unless inbound_data.nil?
+        break if @exiting
+      end
+      log('STDIO server stopped')
+    end
+
+    def stop
+      log('Stopping STDIO server...')
+      @exiting = true
+    end
+
+    def close_connection
+      stop
+    end
+
+    def pipe_is_readable?(stream, timeout = 0.5)
+      read_ready = IO.select([stream], [], [], timeout)
+      read_ready && stream == read_ready[0][0]
+    end
+
+    def read_from_pipe(pipe, timeout = 0.1, &_block)
+      if pipe_is_readable?(pipe, timeout)
+        l = nil
+        begin
+          l = pipe.readpartial(4096)
+        rescue # rubocop:disable Style/RescueStandardError, Lint/HandleExceptions
+          # Any errors here should be swallowed because the pipe could be in any state
+        end
+        # since readpartial may return a nil at EOF, skip returning that value
+        # client_connected = true unless l.nil?
+        yield l unless l.nil?
+      end
+      nil
     end
   end
 end

--- a/lib/puppet-editor-services/simple_stdio_server.rb
+++ b/lib/puppet-editor-services/simple_stdio_server.rb
@@ -1,0 +1,26 @@
+module PuppetEditorServices
+  class SimpleSTDIOServerConnection < SimpleServerConnectionBase
+    attr_accessor :socket
+
+    def initialize(socket)
+      @socket = socket
+    end
+
+    def send_data(data)
+      return false if socket.nil?
+      socket.write(data)
+      true
+    end
+
+    def close_connection_after_writing
+      socket.flush unless socket.nil?
+      simple_tcp_server.remove_connection_async(socket)
+      true
+    end
+
+    def close_connection
+      simple_tcp_server.remove_connection_async(socket)
+      true
+    end
+  end
+end

--- a/lib/puppet-languageserver.rb
+++ b/lib/puppet-languageserver.rb
@@ -155,8 +155,9 @@ module PuppetLanguageServer
       $stdin.sync = true
       $stdout.sync = true
 
-      handler = PuppetLanguageServer::MessageRouter.new
-      handler.socket = $stdout
+      handler = PuppetLanguageServer::JSONRPCHandler.new(options)
+      client_connection = PuppetEditorServices::SimpleSTDIOServerConnection.new($stdout)
+      handler.client_connection = client_connection
       handler.post_init
 
       loop do
@@ -172,7 +173,7 @@ module PuppetLanguageServer
 
       server.add_service(options[:ipaddress], options[:port])
       trap('INT') { server.stop_services(true) }
-      server.start(PuppetLanguageServer::MessageRouter, options, 2)
+      server.start(PuppetLanguageServer::JSONRPCHandler, options, 2)
     end
 
     log_message(:info, 'Language Server exited.')

--- a/lib/puppet-languageserver/puppet_monkey_patches.rb
+++ b/lib/puppet-languageserver/puppet_monkey_patches.rb
@@ -57,3 +57,11 @@ module Puppet
     end
   end
 end
+
+# MUST BE LAST!!!!!!
+# Suppress any warning messages to STDOUT.  It can pollute stdout when running in STDIO mode
+Puppet::Util::Log.newdesttype :null_logger do
+  def handle(msg)
+    PuppetLanguageServer.log_message(:debug, "[PUPPET LOG] [#{msg.level}] #{msg.message}")
+  end
+end

--- a/lib/puppet-languageserver/validation_queue.rb
+++ b/lib/puppet-languageserver/validation_queue.rb
@@ -12,7 +12,7 @@ module PuppetLanguageServer
 
     # Enqueue a file to be validated
     def self.enqueue(file_uri, doc_version, workspace, connection_object)
-      document_type = connection_object.document_type(file_uri)
+      document_type = PuppetLanguageServer::DocumentStore.document_type(file_uri)
 
       unless %i[manifest epp].include?(document_type)
         # Can't validate these types so just emit an empty validation result
@@ -48,7 +48,7 @@ module PuppetLanguageServer
 
     # Synchronously validate a file
     def self.validate_sync(file_uri, doc_version, workspace, connection_object)
-      document_type = connection_object.document_type(file_uri)
+      document_type = PuppetLanguageServer::DocumentStore.document_type(file_uri)
       content = documents.document(file_uri, doc_version)
       return nil if content.nil?
       result = validate(document_type, content, workspace)

--- a/spec/languageserver/integration/puppet-languageserver/message_router_spec.rb
+++ b/spec/languageserver/integration/puppet-languageserver/message_router_spec.rb
@@ -1,8 +1,12 @@
 require 'spec_helper'
 
 describe 'message_router' do
-  let(:subject_options) { nil }
-  let(:subject) { PuppetLanguageServer::MessageRouter.new(subject_options) }
+  let(:subject_options) {}
+  let(:subject) do
+    result = PuppetLanguageServer::MessageRouter.new(subject_options)
+    result.json_rpc_handler = MockJSONRPCHandler.new
+    result
+  end
 
   describe '#receive_request' do
     let(:documents) {{
@@ -104,7 +108,7 @@ describe 'message_router' do
         @default_crash_file = PuppetLanguageServer::CrashDump.default_crash_file
         File.delete(@default_crash_file) if File.exists?(@default_crash_file)
 
-        expect(subject).to receive(:close_connection).and_raise('MockError')
+        expect(subject.json_rpc_handler).to receive(:close_connection).and_raise('MockError')
       end
 
       it 'should create a default crash dump file' do

--- a/spec/languageserver/integration/puppet-languageserver_spec.rb
+++ b/spec/languageserver/integration/puppet-languageserver_spec.rb
@@ -3,11 +3,11 @@ require 'open3'
 require 'socket'
 
 SERVER_TCP_PORT = 8081
-SERVER_HOST = '127.0.0.1'
+SERVER_HOST = '127.0.0.1'.freeze
 
-def start_tcp_server(start_options = ['--no-preload','--timeout=5'])
+def start_tcp_server(start_options = ['--timeout=5'])
   cmd = "ruby puppet-languageserver #{start_options.join(' ')} --port=#{SERVER_TCP_PORT} --ip=0.0.0.0"
-  
+
   stdin, stdout, stderr, wait_thr = Open3.popen3(cmd)
   # Wait for the Language Server to indicate it started
   line = nil
@@ -20,7 +20,7 @@ def start_tcp_server(start_options = ['--no-preload','--timeout=5'])
   wait_thr
 end
 
-def start_stdio_server(start_options = ['--no-preload','--timeout=5'])
+def start_stdio_server(start_options = ['--timeout=5'])
   cmd = "ruby puppet-languageserver #{start_options.join(' ')} --stdio"
 
   stdin, stdout, stderr, wait_thr = Open3.popen3(cmd)

--- a/spec/languageserver/spec_helper.rb
+++ b/spec/languageserver/spec_helper.rb
@@ -46,31 +46,20 @@ RSpec::Matchers.define :be_completion_item_with_type do |value|
 end
 
 # Mock ojects
-class MockJSONRPCHandler < PuppetLanguageServer::JSONRPCHandler
-  attr_accessor :socket
-  attr_accessor :simple_tcp_server
-
-  def post_init
-  end
-
-  def unbind
-  end
-
-  def receive_data(data)
-  end
-
-  def error?
-    false
-  end
-
+class MockConnection < PuppetEditorServices::SimpleServerConnectionBase
   def send_data(data)
     true
   end
+end
 
-  def close_connection_after_writing
+class MockJSONRPCHandler < PuppetLanguageServer::JSONRPCHandler
+  def initialize(options = {})
+    super(options)
+
+    @client_connection = MockConnection.new
   end
 
-  def close_connection
+  def receive_data(data)
   end
 end
 


### PR DESCRIPTION
Previously the different transport types, TCP and STDIO, were very closely coupled which made debugging and maintaining them difficult.  This commit changes the relationships between the server, client connection, message handler and message router classes/objects to be much looser and can therefore be defined/instantiated easier at run time;

---

A new SimpleSTDIOServer class was created which implements a blocking STDIO pipe reader.  It also implements an async stop method which be called when the Language Server wishes to exit.

---

Previously if an invalid logfile location was specified e.g. C:\ or a missing parent directory, the service (Language or Debug Server) would error.  This is undesired as a bad log file should not cause a catastrophic failure.  This commit modifies the logging so that an error occurs when the log file is created it, the error is sent to STDERR, and service continues but with logging disabled.