### PR TITLE
(GH-10)(GH-14) Fix unix loading for language server

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Usage: puppet-languageserver.rb [options]
     -t, --timeout=TIMEOUT            Stop the language server if a client does not connection within TIMEOUT seconds.  A value of zero will not timeout.  Default is 10 seconds
     -d, --no-preload                 ** DEPRECATED ** Do not preload Puppet information when the language server starts.  Default is to preload
         --debug=DEBUG                Output debug information.  Either specify a filename or 'STDOUT'.  Default is no debug output
-    -s, --slow-start                 Delay starting the TCP Server until Puppet initialisation has completed.  Default is to start fast
+    -s, --slow-start                 Delay starting the Language Server until Puppet initialisation has completed.  Default is to start fast
         --stdio                      Runs the server in stdio mode, without a TCP listener
         --enable-file-cache          Enables the file system cache for Puppet Objects (types, class etc.)
         --local-workspace=PATH       The workspace or file path that will be used to provide module-specific functionality. Default is no workspace path.

--- a/lib/puppet-languageserver.rb
+++ b/lib/puppet-languageserver.rb
@@ -37,7 +37,7 @@ module PuppetLanguageServer
         connection_timeout: 10,
         preload_puppet: true,
         debug: nil,
-        fast_start_tcpserver: true,
+        fast_start_langserver: true,
         workspace: nil
       }
 
@@ -69,8 +69,8 @@ module PuppetLanguageServer
           args[:debug] = debug
         end
 
-        opts.on('-s', '--slow-start', 'Delay starting the TCP Server until Puppet initialisation has completed.  Default is to start fast') do |_misc|
-          args[:fast_start_tcpserver] = false
+        opts.on('-s', '--slow-start', 'Delay starting the Language Server until Puppet initialisation has completed.  Default is to start fast') do |_misc|
+          args[:fast_start_langserver] = false
         end
 
         opts.on('--stdio', 'Runs the server in stdio mode, without a TCP listener') do |_misc|
@@ -116,7 +116,7 @@ module PuppetLanguageServer
     PuppetLanguageServer::PuppetHelper.configure_cache(options[:cache])
 
     log_message(:info, 'Initializing settings...')
-    if options[:fast_start_tcpserver]
+    if options[:fast_start_langserver]
       Thread.new do
         init_puppet_worker(options)
       end

--- a/lib/puppet-languageserver/puppet_helper.rb
+++ b/lib/puppet-languageserver/puppet_helper.rb
@@ -150,10 +150,8 @@ module PuppetLanguageServer
       unless Puppet.settings[:environmentpath].nil?
         module_path_list << File.join(Puppet.settings[:environmentpath], Puppet.settings[:environment], 'modules') unless Puppet.settings[:environment].nil?
 
-        module_path_list.concat(Pathname.new(Puppet.settings[:environmentpath])
-                                        .children
-                                        .select { |c| c.directory? }
-                                        .collect { |c| File.join(c, 'modules') })
+        env_path = Pathname.new(Puppet.settings[:environmentpath])
+        module_path_list.concat(env_path.children.select { |c| c.directory? }.collect { |c| File.join(c, 'modules') }) if env_path.exist?
       end
       module_path_list.uniq!
       PuppetLanguageServer.log_message(:debug, "[PuppetHelper::_load_default_classes] Loading classes from #{module_path_list}")

--- a/spec/languageserver/spec_helper.rb
+++ b/spec/languageserver/spec_helper.rb
@@ -11,7 +11,7 @@ $fixtures_dir = File.join(File.dirname(__FILE__),'fixtures')
 
 # Currently there is no way to re-initialize the puppet loader so for the moment
 # all tests must run off the single puppet config settings instead of per example setting
-server_options = PuppetLanguageServer::CommandLineParser.parse([])
+server_options = PuppetLanguageServer::CommandLineParser.parse(['--slow-start'])
 server_options[:puppet_settings] = ['--vardir',File.join($fixtures_dir,'cache'),
                                     '--confdir',File.join($fixtures_dir,'confdir')]
 PuppetLanguageServer::init_puppet(server_options)

--- a/spec/languageserver/unit/puppet-languageserver/puppet_helper/file_cache_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/puppet_helper/file_cache_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe 'PuppetLanguageServer::PuppetHelper::PersistentFileCache' do
+  let(:subject) { PuppetLanguageServer::PuppetHelper::PersistentFileCache.new(nil, {}) }
+
+  describe '#initialize' do
+    it 'should use Dir.tmpdir to detect cache directory' do
+      expect(Dir).to receive(:tmpdir).and_call_original
+
+      subject
+    end
+
+    context 'when cache directory cannot be created' do
+      before(:each) do
+        expect(Dir).to receive(:tmpdir).and_return('/dir/does/not/exist')
+      end
+
+      it 'should disable cache if cache dir is unable to be created' do
+        subject
+
+        expect(subject.cache_disabled?).to be true
+      end
+
+      it 'should return nil for loading files' do
+        expect(subject.load('anyfile', 'a_key')).to be_nil
+      end
+
+      it 'should return false for saving files' do
+        expect(subject.save!('anyfile', 'a_key')).to be false
+      end
+    end
+  end
+end

--- a/spec/languageserver/unit/puppet-languageserver/puppet_helper_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/puppet_helper_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe 'PuppetLanguageServer::PuppetHelper' do
+  let(:subject) { PuppetLanguageServer::PuppetHelper }
+
+  before(:all) { wait_for_puppet_loading }
+
+  describe '#_load_default_classes' do
+    # Note this is a private method, so this test can be a little brittle
+
+    it 'should not error when the Puppet.setting[environmentpath] does not exist' do
+      mocked_puppet_settings = Puppet.settings
+      mocked_puppet_settings[:environmentpath] = 'dir/does/not/exist'
+
+      expect(Puppet).to receive(:settings).and_return(mocked_puppet_settings).at_least(:once)
+
+      result = subject.send :_load_default_classes
+    end
+  end
+end


### PR DESCRIPTION
Previously the language server would crash if the Environment Path did not exist.
This can happen when pluginsync syncs all the files into the lib directory, or a
newly created puppet agent.  This commit changes the load behaviour to instead
check if the directory exists and just ignore it if it does not.  This commit
also adds a test for this scenario.

---

Previously the persistent file cache would crash if the temporary directory
could not be detected, or did not exist.  This commit changes the detection to
be cross platform supported and adds error detection if the cache directory
could not be created.  If the the cache directory is unable to be created all
calls to the persistent file cache then emulate as if the cache is empty thereby
still allowing the language server to operate.  This commit also adds tests for
this scenario.