### PR TITLE
(GH-28) Add basic puppetfile support

### DIFF
--- a/lib/puppet-languageserver/providers.rb
+++ b/lib/puppet-languageserver/providers.rb
@@ -4,6 +4,12 @@
   manifest/definition_provider
   manifest/validation_provider
   manifest/hover_provider
+  puppetfile/r10k/module/base
+  puppetfile/r10k/module/forge
+  puppetfile/r10k/module/invalid
+  puppetfile/r10k/module/local
+  puppetfile/r10k/module/git
+  puppetfile/r10k/module/svn
   puppetfile/r10k/puppetfile
   puppetfile/validation_provider
 ].each do |lib|

--- a/lib/puppet-languageserver/providers.rb
+++ b/lib/puppet-languageserver/providers.rb
@@ -4,6 +4,8 @@
   manifest/definition_provider
   manifest/validation_provider
   manifest/hover_provider
+  puppetfile/r10k/puppetfile
+  puppetfile/validation_provider
 ].each do |lib|
   begin
     require "puppet-languageserver/#{lib}"

--- a/lib/puppet-languageserver/puppetfile/r10k/module/base.rb
+++ b/lib/puppet-languageserver/puppetfile/r10k/module/base.rb
@@ -1,0 +1,63 @@
+module PuppetLanguageServer
+  module Puppetfile
+    module R10K
+      module Module
+        def self.from_puppetfile(title, args)
+          return Git.new(title, args) if Git.implements?(title, args)
+          return Svn.new(title, args) if Svn.implements?(title, args)
+          return Local.new(title, args) if Local.implements?(title, args)
+          return Forge.new(title, args) if Forge.implements?(title, args)
+
+          Invalid.new(title, args)
+        end
+
+        class Base
+          # The full title of the module
+          attr_reader :title
+
+          # The name of the module
+          attr_reader :name
+
+          # The line number where this module is first found in Puppetfile
+          attr_reader :puppetfile_line_number
+
+          def initialize(title, args)
+            @title = title
+            @args = args
+            @owner, @name = parse_title(@title)
+
+            @puppetfile_line_number = find_load_location
+          end
+
+          # Should be overridden in concrete module classes
+          def version
+            nil
+          end
+
+          # Should be overridden in concrete module classes
+          def properties
+            {}
+          end
+
+          private
+
+          def parse_title(title)
+            if (match = title.match(/\A(\w+)\Z/))
+              [nil, match[1]]
+            elsif (match = title.match(/\A(\w+)[-\/](\w+)\Z/))
+              [match[1], match[2]]
+            else
+              raise ArgumentError, format("Module name (%<title>s) must match either 'modulename' or 'owner/modulename'", title: title)
+            end
+          end
+
+          def find_load_location
+            loc = Kernel.caller_locations
+                        .find { |call_loc| call_loc.absolute_path == PuppetLanguageServer::Puppetfile::R10K::PUPPETFILE_MONIKER }
+            loc.nil? ? 0 : loc.lineno - 1 # Line numbers from ruby are base 1
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/puppet-languageserver/puppetfile/r10k/module/forge.rb
+++ b/lib/puppet-languageserver/puppetfile/r10k/module/forge.rb
@@ -1,0 +1,42 @@
+module PuppetLanguageServer
+  module Puppetfile
+    module R10K
+      module Module
+        class Forge < PuppetLanguageServer::Puppetfile::R10K::Module::Base
+          def self.implements?(name, args)
+            !name.match(/\A(\w+)[-\/](\w+)\Z/).nil? && valid_version?(args)
+          end
+
+          def self.valid_version?(value)
+            return false unless value.is_a?(String) || value.is_a?(Symbol)
+            value == :latest || value.nil? || valid_version_string?(value)
+          end
+
+          def properties
+            {
+              :type => :forge
+            }
+          end
+
+          # Version string matching regexes
+          # From Semantic Puppet gem
+          REGEX_NUMERIC = '(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)'.freeze # Major . Minor . Patch
+          REGEX_PRE     = '(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?'.freeze # Prerelease
+          REGEX_BUILD   = '(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?'.freeze # Build
+          REGEX_FULL    = REGEX_NUMERIC + REGEX_PRE + REGEX_BUILD.freeze
+          REGEX_FULL_RX = /\A#{REGEX_FULL}\Z/
+
+          def self.valid_version_string?(value)
+            match = value.match(REGEX_FULL_RX)
+            if match.nil?
+              false
+            else
+              prerelease = match[4]
+              prerelease.nil? || prerelease.split('.').all? { |x| x !~ /^0\d+$/ }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/puppet-languageserver/puppetfile/r10k/module/git.rb
+++ b/lib/puppet-languageserver/puppetfile/r10k/module/git.rb
@@ -1,0 +1,21 @@
+module PuppetLanguageServer
+  module Puppetfile
+    module R10K
+      module Module
+        class Git < PuppetLanguageServer::Puppetfile::R10K::Module::Base
+          def self.implements?(_name, args)
+            args.is_a?(Hash) && args.key?(:git)
+          rescue StandardError
+            false
+          end
+
+          def properties
+            {
+              :type => :git
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/puppet-languageserver/puppetfile/r10k/module/invalid.rb
+++ b/lib/puppet-languageserver/puppetfile/r10k/module/invalid.rb
@@ -1,0 +1,27 @@
+# This is a special module definition.  It's the catchall when no other module type can handle it
+
+module PuppetLanguageServer
+  module Puppetfile
+    module R10K
+      module Module
+        class Invalid < PuppetLanguageServer::Puppetfile::R10K::Module::Base
+          def self.implements?(_name, _args)
+            true
+          end
+
+          def initialize(title, args)
+            super
+            @error_message = format("Module %<title>s with args %<args>s doesn't have an implementation. (Are you using the right arguments?)", title: title, args: args.inspect)
+          end
+
+          def properties
+            {
+              :type => :invalid,
+              :error_message => @error_message
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/puppet-languageserver/puppetfile/r10k/module/local.rb
+++ b/lib/puppet-languageserver/puppetfile/r10k/module/local.rb
@@ -1,0 +1,21 @@
+module PuppetLanguageServer
+  module Puppetfile
+    module R10K
+      module Module
+        class Local < PuppetLanguageServer::Puppetfile::R10K::Module::Base
+          def self.implements?(_name, args)
+            args.is_a?(Hash) && args.key?(:local)
+          rescue StandardError
+            false
+          end
+
+          def properties
+            {
+              :type => :local
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/puppet-languageserver/puppetfile/r10k/module/svn.rb
+++ b/lib/puppet-languageserver/puppetfile/r10k/module/svn.rb
@@ -1,0 +1,21 @@
+module PuppetLanguageServer
+  module Puppetfile
+    module R10K
+      module Module
+        class Svn < PuppetLanguageServer::Puppetfile::R10K::Module::Base
+          def self.implements?(_name, args)
+            args.is_a?(Hash) && args.key?(:svn)
+          rescue StandardError
+            false
+          end
+
+          def properties
+            {
+              :type => :svn
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/puppet-languageserver/puppetfile/r10k/puppetfile.rb
+++ b/lib/puppet-languageserver/puppetfile/r10k/puppetfile.rb
@@ -1,0 +1,37 @@
+module PuppetLanguageServer
+  module Puppetfile
+    module R10K
+      PUPPETFILE_MONIKER ||= 'Puppetfile'.freeze
+
+      class Puppetfile
+        def load!(puppetfile_contents)
+          puppetfile = DSL.new(self)
+          puppetfile.instance_eval(puppetfile_contents, PUPPETFILE_MONIKER)
+        end
+
+        class DSL
+          def initialize(parent)
+            @parent = parent
+          end
+
+          # @param [String] name
+          # @param [*Object] args
+          def mod(_name, _args = nil)
+          end
+
+          # @param [String] forge
+          def forge(_location)
+          end
+
+          # @param [String] moduledir
+          def moduledir(_location)
+          end
+
+          def method_missing(method, *_args) # rubocop:disable Style/MethodMissing
+            raise NoMethodError, format("Unknown method '%<method>s'", method: method)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/puppet-languageserver/puppetfile/r10k/puppetfile.rb
+++ b/lib/puppet-languageserver/puppetfile/r10k/puppetfile.rb
@@ -4,9 +4,16 @@ module PuppetLanguageServer
       PUPPETFILE_MONIKER ||= 'Puppetfile'.freeze
 
       class Puppetfile
+        attr_reader :modules
+
         def load!(puppetfile_contents)
           puppetfile = DSL.new(self)
+          @modules = []
           puppetfile.instance_eval(puppetfile_contents, PUPPETFILE_MONIKER)
+        end
+
+        def add_module(name, args)
+          @modules << Module.from_puppetfile(name, args)
         end
 
         class DSL
@@ -16,7 +23,8 @@ module PuppetLanguageServer
 
           # @param [String] name
           # @param [*Object] args
-          def mod(_name, _args = nil)
+          def mod(name, args = nil)
+            @parent.add_module(name, args)
           end
 
           # @param [String] forge
@@ -27,7 +35,7 @@ module PuppetLanguageServer
           def moduledir(_location)
           end
 
-          def method_missing(method, *_args) # rubocop:disable Style/MethodMissing
+          def method_missing(method, *_args) # rubocop:disable Style/MethodMissingSuper, Style/MissingRespondToMissing
             raise NoMethodError, format("Unknown method '%<method>s'", method: method)
           end
         end

--- a/lib/puppet-languageserver/puppetfile/validation_provider.rb
+++ b/lib/puppet-languageserver/puppetfile/validation_provider.rb
@@ -1,0 +1,43 @@
+module PuppetLanguageServer
+  module Puppetfile
+    module ValidationProvider
+      def self.max_line_length
+        # TODO: ... need to figure out the actual line length
+        1000
+      end
+
+      def self.validate(content, _workspace, _max_problems = 100)
+        result = []
+        # TODO: Need to implement max_problems
+        _problems = 0
+
+        # Attempt to parse the file
+        puppetfile = nil
+        begin
+          puppetfile = PuppetLanguageServer::Puppetfile::R10K::Puppetfile.new
+          puppetfile.load!(content)
+        rescue StandardError, SyntaxError, LoadError => detail
+          # Find the originating error from within the puppetfile
+          loc = detail.backtrace_locations
+                      .select { |item| item.absolute_path == PuppetLanguageServer::Puppetfile::R10K::PUPPETFILE_MONIKER }
+                      .first
+          start_line_number = loc.nil? ? 0 : loc.lineno - 1 # Line numbers from ruby are base 1
+          end_line_number = loc.nil? ? content.lines.count - 1 : loc.lineno - 1 # Line numbers from ruby are base 1
+          # Note - Ruby doesn't give a character position so just highlight the entire line
+          result << LanguageServer::Diagnostic.create('severity' => LanguageServer::DIAGNOSTICSEVERITY_ERROR,
+                                                      'fromline' => start_line_number,
+                                                      'toline'   => end_line_number,
+                                                      'fromchar' => 0,
+                                                      'tochar'   => max_line_length,
+                                                      'source'   => 'Puppet',
+                                                      'message'  => detail.to_s)
+
+          puppetfile = nil
+        end
+        return result if puppetfile.nil?
+
+        result
+      end
+    end
+  end
+end

--- a/lib/puppet-languageserver/validation_queue.rb
+++ b/lib/puppet-languageserver/validation_queue.rb
@@ -14,7 +14,7 @@ module PuppetLanguageServer
     def self.enqueue(file_uri, doc_version, workspace, connection_object)
       document_type = PuppetLanguageServer::DocumentStore.document_type(file_uri)
 
-      unless %i[manifest epp].include?(document_type)
+      unless %i[manifest epp puppetfile].include?(document_type)
         # Can't validate these types so just emit an empty validation result
         connection_object.reply_diagnostics(file_uri, [])
         return
@@ -86,6 +86,8 @@ module PuppetLanguageServer
         PuppetLanguageServer::Manifest::ValidationProvider.validate(content, workspace)
       when :epp
         PuppetLanguageServer::Epp::ValidationProvider.validate(content, workspace)
+      when :puppetfile
+        PuppetLanguageServer::Puppetfile::ValidationProvider.validate(content, workspace)
       else
         []
       end

--- a/spec/languageserver/unit/puppet-languageserver/puppetfile/validation_provider_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/puppetfile/validation_provider_spec.rb
@@ -27,6 +27,15 @@ describe 'PuppetLanguageServer::Puppetfile::ValidationProvider' do
         mod 'gittagmodule',
           :git => 'https://github.com/username/repo',
           :tag => '0.1'
+
+        # Svn style modules
+        mod 'svnmodule',
+          :svn => 'svn://host/repo',
+          :rev => 'abc123'
+
+        # local style modules
+        mod 'localmodule',
+          :local => 'true'
         EOT
       end
 
@@ -91,7 +100,6 @@ describe 'PuppetLanguageServer::Puppetfile::ValidationProvider' do
         expect(lint_error['message']).to match('not_loadable')
         expect(lint_error['range']['start']['line']).to eq(5)
         expect(lint_error['range']['end']['line']).to eq(5)
-        expect(lint_error['range']).to_not be_nil
         expect(lint_error['severity']).to eq(LanguageServer::DIAGNOSTICSEVERITY_ERROR)
       end
     end
@@ -125,11 +133,9 @@ describe 'PuppetLanguageServer::Puppetfile::ValidationProvider' do
         expect(lint_error['message']).to match('A Mock Runtime Error')
         expect(lint_error['range']['start']['line']).to eq(10)
         expect(lint_error['range']['end']['line']).to eq(10)
-        expect(lint_error['range']).to_not be_nil
         expect(lint_error['severity']).to eq(LanguageServer::DIAGNOSTICSEVERITY_ERROR)
       end
     end
-
 
     context 'with an unknown method in the Puppetfile' do
       let(:content) do <<-EOT
@@ -156,6 +162,211 @@ describe 'PuppetLanguageServer::Puppetfile::ValidationProvider' do
         expect(lint_error['range']['start']['line']).to eq(9)
         expect(lint_error['range']['end']['line']).to eq(9)
         expect(lint_error['severity']).to eq(LanguageServer::DIAGNOSTICSEVERITY_ERROR)
+      end
+    end
+
+    context 'with an unknown or invalid module parameter set' do
+      let(:content) do <<-EOT
+        forge 'https://forge.puppetlabs.com/'
+
+        mod 'fifthelement',
+          :i_am_a_meat_popsicle => true
+        EOT
+      end
+
+      it 'should return a validation error' do
+        lint_error = subject.validate(content, nil)[0]
+
+        expect(lint_error['source']).to eq('Puppet')
+        expect(lint_error['message']).to match('doesn\'t have an implementation')
+        expect(lint_error['range']['start']['line']).to eq(2)
+        expect(lint_error['range']['end']['line']).to eq(2)
+        expect(lint_error['severity']).to eq(LanguageServer::DIAGNOSTICSEVERITY_ERROR)
+      end
+    end
+
+    context 'with duplicate, valid and invalid modules defined' do
+      let(:content) do <<-EOT
+        forge 'https://forge.puppetlabs.com/'
+
+        mod 'duplicate-module',      '1.0.0'
+
+        mod 'duplicatemodule',
+          :git => 'https://github.com/username/repo'
+
+        mod 'duplicatemodule',
+          :i_am_a_meat_popsicle => true
+        EOT
+      end
+
+      it 'should return all validation error' do
+        lint_errors = subject.validate(content, nil)
+        expect(lint_errors.count).to eq(3)
+
+        lint_error = lint_errors[0]
+        expect(lint_error['source']).to eq('Puppet')
+        expect(lint_error['message']).to match('doesn\'t have an implementation')
+        expect(lint_error['range']['start']['line']).to eq(7)
+        expect(lint_error['range']['end']['line']).to eq(7)
+        expect(lint_error['severity']).to eq(LanguageServer::DIAGNOSTICSEVERITY_ERROR)
+
+        lint_error = lint_errors[1]
+        expect(lint_error['source']).to eq('Puppet')
+        expect(lint_error['message']).to match(/Duplicate.+duplicatemodule/)
+        expect(lint_error['range']['start']['line']).to eq(4)
+        expect(lint_error['range']['end']['line']).to eq(4)
+        expect(lint_error['severity']).to eq(LanguageServer::DIAGNOSTICSEVERITY_ERROR)
+
+        lint_error = lint_errors[2]
+        expect(lint_error['source']).to eq('Puppet')
+        expect(lint_error['message']).to match(/Duplicate.+duplicatemodule/)
+        expect(lint_error['range']['start']['line']).to eq(7)
+        expect(lint_error['range']['end']['line']).to eq(7)
+        expect(lint_error['severity']).to eq(LanguageServer::DIAGNOSTICSEVERITY_ERROR)
+      end
+    end
+
+    # Git style module tests
+    context 'with a single git style module' do
+      context 'with valid minimal parameters for a git module' do
+        it 'should return no validation errors' do
+          content = <<-EOT
+            mod 'gitcommitmodule',
+              :git => 'https://github.com/username/repo'
+            EOT
+
+          result = subject.validate(content, nil)
+
+          expect(result).to eq([])
+        end
+      end
+    end
+
+    # Svn style module tests
+    context 'with a single svn style module' do
+      context 'with valid minimal parameters for a svn module' do
+        it 'should return no validation errors' do
+          content = <<-EOT
+            mod 'svnmodule',
+              :svn => 'svn://host/repo'
+            EOT
+
+          result = subject.validate(content, nil)
+
+          expect(result).to eq([])
+        end
+      end
+    end
+
+    # Local style module tests
+    context 'with a single local style module' do
+      context 'with valid parameters for a local module' do
+        it 'should return no validation errors' do
+          content = <<-EOT
+            mod 'localmodule',
+              :local => true
+            EOT
+
+          result = subject.validate(content, nil)
+
+          expect(result).to eq([])
+        end
+      end
+    end
+
+    # Forge style module tests
+    context 'with a single forge style module' do
+      good_module_names = ['puppetlabs-modulename', 'puppetlabs/modulename']
+      bad_module_names = ['puppetlabs:modulename', 'puppetlabs\\modulename', 'puppetlabs modulename', 'puppetlabsmodulename']
+
+      good_module_versions = ['1.0.0', '10.1.2']
+      bad_module_versions = ['1.x', '1.2', '1.0.xxx0']
+
+      good_module_name = good_module_names[0]
+      good_module_version = good_module_versions[0]
+
+      context 'with a valid module version' do
+        good_module_versions.each do |testcase|
+          it "should return no validation errors for a module version of #{testcase}" do
+            content = <<-EOT
+              forge 'https://forge.puppetlabs.com/'
+
+              # Modules from the Puppet Forge
+              mod '#{good_module_name}', '#{testcase}'
+              EOT
+
+            result = subject.validate(content, nil)
+
+            expect(result).to eq([])
+          end
+        end
+      end
+
+      context 'with an invalid module version' do
+        bad_module_versions.each do |testcase|
+          it "should return a validation error for a module version of #{testcase}" do
+            content = <<-EOT
+              forge 'https://forge.puppetlabs.com/'
+
+              # Modules from the Puppet Forge
+              mod '#{good_module_name}', '#{testcase}'
+              EOT
+
+            lint_error = subject.validate(content, nil)
+            expect(lint_error.count).to eq(1)
+            lint_error = lint_error[0]
+
+            expect(lint_error['source']).to eq('Puppet')
+            # The horrible gsub is for backslashes in regexes
+            expect(lint_error['message']).to match(testcase.gsub('\\','\\\\\\\\'))
+            expect(lint_error['range']['start']['line']).to eq(3)
+            expect(lint_error['range']['end']['line']).to eq(3)
+            expect(lint_error['range']).to_not be_nil
+            expect(lint_error['severity']).to eq(LanguageServer::DIAGNOSTICSEVERITY_ERROR)
+          end
+        end
+      end
+
+      context 'with a valid module name' do
+        good_module_names.each do |testcase|
+          it "should return no validation errors for a module name of #{testcase}" do
+            content = <<-EOT
+              forge 'https://forge.puppetlabs.com/'
+
+              # Modules from the Puppet Forge
+              mod '#{testcase}', '#{good_module_version}'
+              EOT
+
+            result = subject.validate(content, nil)
+
+            expect(result).to eq([])
+          end
+        end
+      end
+
+      context 'with an invalid module name' do
+        bad_module_names.each do |testcase|
+          it "should return a validation error for a module name of #{testcase}" do
+            content = <<-EOT
+              forge 'https://forge.puppetlabs.com/'
+
+              # Modules from the Puppet Forge
+              mod '#{testcase}', '#{good_module_version}'
+              EOT
+
+            lint_error = subject.validate(content, nil)
+            expect(lint_error.count).to eq(1)
+            lint_error = lint_error[0]
+
+            expect(lint_error['source']).to eq('Puppet')
+            # The horrible gsub is for backslashes in regexes
+            expect(lint_error['message']).to match(testcase.gsub('\\','\\\\\\\\'))
+            expect(lint_error['range']['start']['line']).to eq(3)
+            expect(lint_error['range']['end']['line']).to eq(3)
+            expect(lint_error['range']).to_not be_nil
+            expect(lint_error['severity']).to eq(LanguageServer::DIAGNOSTICSEVERITY_ERROR)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Previously the language server could identify a Puppetfile file but would not
actually do anything with it.  This commit;

* Adds a basic Puppetfile parser based on the skeleton of the R10K gem
* Adds valiadation that the ruby style Puppetfile could be parsed and reports
  diagnostic errors if found
* Integrates into the async validation process
* Adds unit tests for the provider

---

Previously basic validation for Puppetfile's was added.  This commit;

* Adds more detailed parsing of Puppetfile to extract different types of modules
  git, local, svn or forge.  These types have enough information to identify a
  module type, and basic name/title/version validation
* Adds an internal only module type called invalid which is used to track
  invalid module definitions.  Without this, the validation process would find
  the first invalid module and ignore subsequent entries.
* Due to semantic_puppet not being available in all puppet editions, the version
  regexes are vendored into the code instead of calling out to Semantic Puppet.
* Adds detection of invalid modules and duplicate module definitions
* Adds tests for these scenarios