### PR TITLE
(GH-31) Use canonical names for line based breakpoints

### DIFF
--- a/lib/puppet-editor-services/version.rb
+++ b/lib/puppet-editor-services/version.rb
@@ -10,7 +10,7 @@ module PuppetEditorServices
     version_file = File.join(File.dirname(__FILE__), 'VERSION')
     version = read_version_file(version_file)
 
-    @editor_services_version = version ? version : PUPPETEDITORSERVICESVERSION
+    @editor_services_version = version.nil? ? PUPPETEDITORSERVICESVERSION : version
   end
 
   # Sets the editor services version

--- a/lib/puppet-languageserver/crash_dump.rb
+++ b/lib/puppet-languageserver/crash_dump.rb
@@ -11,7 +11,7 @@ module PuppetLanguageServer
       facter_version         = Facter.version rescue 'Unknown' # rubocop:disable Lint/RescueWithoutErrorClass, Style/RescueModifier
       languageserver_version = PuppetLanguageServer.version rescue 'Unknown' # rubocop:disable Lint/RescueWithoutErrorClass, Style/RescueModifier
 
-      # rubocop:disable Layout/IndentHeredoc, Style/FormatStringToken
+      # rubocop:disable Layout/IndentHeredoc, Layout/ClosingHeredocIndentation, Style/FormatStringToken
       crashtext = <<-TEXT
 Puppet Language Server Crash File
 -=--=--=--=--=--=--=--=--=--=--=-
@@ -28,7 +28,7 @@ Backtrace
 #{err.backtrace.join("\n")}
 
 TEXT
-      # rubocop:enable Layout/IndentHeredoc, Style/FormatStringToken
+      # rubocop:enable Layout/IndentHeredoc, Layout/ClosingHeredocIndentation, Style/FormatStringToken
 
       # Append the documents in the cache
       PuppetLanguageServer::DocumentStore.document_uris.each do |uri|

--- a/lib/puppet-languageserver/puppet_monkey_patches.rb
+++ b/lib/puppet-languageserver/puppet_monkey_patches.rb
@@ -1,5 +1,3 @@
-
-
 # Monkey Patch 3.x functions so where know where they were loaded from
 require 'puppet/parser/functions'
 module Puppet


### PR DESCRIPTION
Previously VS Code was sending filenames in the API calls which always matched
the file system, however this is no longer the case.  This exposed a bug in the
debug adapter which depended on this behaviour. This commit modifies the line
based breakpoints to use a canonical filename.  However due to debug server
never knowing what naming scheme is coming from the editor we had to resort to
a naive method of just setting it to all lowercase.  This _may_ cause an issue
on case sensitive file systems however Puppet style guides prohibit manifest
names only changing by case.