### PR TITLE
(GH-36) Use automatic port assignment as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ Note the language server will stop after 10 seconds if no client connection is m
 
 ```
 Usage: puppet-languageserver.rb [options]
-    -p, --port=PORT                  TCP Port to listen on.  Default is 8081
-    -i, --ip=ADDRESS                 IP Address to listen on (0.0.0.0 for all interfaces).  Default is 127.0.0.1
+    -p, --port=PORT                  TCP Port to listen on.  Default is random port
+    -i, --ip=ADDRESS                 IP Address to listen on (0.0.0.0 for all interfaces).  Default is localhost
     -c, --no-stop                    Do not stop the language server once a client disconnects.  Default is to stop
     -t, --timeout=TIMEOUT            Stop the language server if a client does not connection within TIMEOUT seconds.  A value of zero will not timeout.  Default is 10 seconds
     -d, --no-preload                 ** DEPRECATED ** Do not preload Puppet information when the language server starts.  Default is to preload
@@ -185,8 +185,8 @@ Note the debug server will stop after 10 seconds if no client connection is made
 
 ```
 Usage: puppet-debugserver.rb [options]
-    -p, --port=PORT                  TCP Port to listen on.  Default is 8082
-    -i, --ip=ADDRESS                 IP Address to listen on (0.0.0.0 for all interfaces).  Default is 127.0.0.1
+    -p, --port=PORT                  TCP Port to listen on.  Default is random port}
+    -i, --ip=ADDRESS                 IP Address to listen on (0.0.0.0 for all interfaces).  Default is localhost
     -t, --timeout=TIMEOUT            Stop the Debug Server if a client does not connection within TIMEOUT seconds.  A value of zero will not timeout.  Default is 10 seconds
         --debug=DEBUG                Output debug information.  Either specify a filename or 'STDOUT'.  Default is no debug output
     -h, --help                       Prints this help

--- a/lib/puppet-debugserver.rb
+++ b/lib/puppet-debugserver.rb
@@ -21,8 +21,8 @@ module PuppetDebugServer
     def self.parse(options)
       # Set defaults here
       args = {
-        port: 8082,
-        ipaddress: '127.0.0.1',
+        port: nil,
+        ipaddress: 'localhost',
         stop_on_client_exit: true,
         connection_timeout: 10,
         debug: nil
@@ -31,7 +31,7 @@ module PuppetDebugServer
       opt_parser = OptionParser.new do |opts|
         opts.banner = 'Usage: puppet-debugserver.rb [options]'
 
-        opts.on('-pPORT', '--port=PORT', "TCP Port to listen on.  Default is #{args[:port]}") do |port|
+        opts.on('-pPORT', '--port=PORT', "TCP Port to listen on.  Default is random port}") do |port|
           args[:port] = port.to_i
         end
 

--- a/lib/puppet-editor-services/simple_tcp_server.rb
+++ b/lib/puppet-editor-services/simple_tcp_server.rb
@@ -251,13 +251,13 @@ module PuppetEditorServices
     # IO - listening sockets (services)
 
     # @api public
-    def add_service(hostname = '127.0.0.1', port = 8081, parameters = {})
-      parameters[:port] = port
+    def add_service(hostname = 'localhost', port = nil, parameters = {})
+      hostname = 'localhost' if hostname.nil? || hostname.empty?
+      service = TCPServer.new(hostname, port)
       parameters[:hostname] = hostname
-      parameters.update port if port.is_a?(Hash)
-      service = TCPServer.new(parameters[:hostname], parameters[:port])
+      parameters[:port] = service.local_address.ip_port
       self.class.s_locker.synchronize { self.class.services[service] = parameters }
-      callback(self, :log, "Started listening on #{hostname}:#{port}.")
+      callback(self, :log, "Started listening on #{hostname}:#{parameters[:port]}.")
       true
     end
 

--- a/lib/puppet-languageserver.rb
+++ b/lib/puppet-languageserver.rb
@@ -42,8 +42,8 @@ module PuppetLanguageServer
       # Set defaults here
       args = {
         stdio: false,
-        port: 8081,
-        ipaddress: '127.0.0.1',
+        port: nil,
+        ipaddress: 'localhost',
         stop_on_client_exit: true,
         connection_timeout: 10,
         preload_puppet: true,
@@ -55,7 +55,7 @@ module PuppetLanguageServer
       opt_parser = OptionParser.new do |opts|
         opts.banner = 'Usage: puppet-languageserver.rb [options]'
 
-        opts.on('-pPORT', '--port=PORT', "TCP Port to listen on.  Default is #{args[:port]}") do |port|
+        opts.on('-pPORT', '--port=PORT', "TCP Port to listen on.  Default is random port") do |port|
           args[:port] = port.to_i
         end
 


### PR DESCRIPTION
Previously the language and debug server used hardocoded default ports.  This
commit changes the behaviour to use automatically generated high-ports when
starting, but still honours manual port specification

This commit also updates the default hostname from 127.0.0.1 to localhost to
add support for IP6 only systems.