### PR TITLE
(maint) Force rubocop to only use project config

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,6 +19,8 @@ if rubocop_available
   desc 'Run RuboCop'
   RuboCop::RakeTask.new(:rubocop) do |task|
     task.options << '--display-cop-names'
+    task.options << '--config'
+    task.options << '.rubocop.yml'
   end
 end
 


### PR DESCRIPTION
Previously rubocop would search child directories for its configuration file
which caused problems with Puppet-Lint as it uses an older version.  This commit
updates the rake task to only use the project config file.