### PR TITLE
(maint) Prepare for v0.13.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Unreleased
 
+## 0.13.0 - 2018-07-21
+
+### Changed
+
+- ([GH-36](https://github.com/lingua-pupuli/puppet-editor-services/issues/36)) Use automatic port assignment as default
+
+### Fixed
+
+- ([GH-31](https://github.com/lingua-pupuli/puppet-editor-services/issues/31)) Use canonical names for line based breakpoints
+- ([GH-46](https://github.com/lingua-pupuli/puppet-editor-services/issues/46)) Detect Puppet Environment correctly
+- Minor fixes for rubocop
+
 ## 0.12.0 - 2018-06-01
 
 ### Added

--- a/lib/puppet-editor-services/version.rb
+++ b/lib/puppet-editor-services/version.rb
@@ -1,5 +1,5 @@
 module PuppetEditorServices
-  PUPPETEDITORSERVICESVERSION = '0.12.0'.freeze unless defined? PUPPETEDITORSERVICESVERSION
+  PUPPETEDITORSERVICESVERSION = '0.13.0'.freeze unless defined? PUPPETEDITORSERVICESVERSION
 
   # @api public
   #


### PR DESCRIPTION
This commit prepares Puppet Editor Services for a version 0.13.0 release.