### PR TITLE
(GH-49) Exit STDIO loop if STDIN reaches EOF

### DIFF
--- a/lib/puppet-editor-services/simple_stdio_server.rb
+++ b/lib/puppet-editor-services/simple_stdio_server.rb
@@ -78,6 +78,9 @@ module PuppetEditorServices
         l = nil
         begin
           l = pipe.readpartial(4096)
+        rescue EOFError
+          log('Reading from pipe has reached End of File.  Exiting STDIO server')
+          stop
         rescue # rubocop:disable Style/RescueStandardError, Lint/HandleExceptions
           # Any errors here should be swallowed because the pipe could be in any state
         end


### PR DESCRIPTION
Previously if the STDIN pipe was in a bad state, the pipe would appear to be
readable however when it is attempted to be read, it was throwing an EOF.  This
can occur when Javascript closes a child language server process.  This wasn't
caught in development due to the INT trap that is setup globally, so when
developers pressed Ctrl-C in the javascript parent process, the ruby child
process also saw it and terminated correctly.

Fixes #49 