### PR TITLE
(GH-54) Support Puppet 6 in the Language Server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,7 @@ matrix:
 env:
   matrix:
     # Language Server testing
-    # LTS Agent
-    - PUPPET_GEM_VERSION="~> 4.7.0"
-      RUBY_VER=2.1.9
-      RAKE_TASK=test_languageserver
-
-    # Latest 4.x branch
+    # Latest 4.x branch (Covers LTS too)
     - PUPPET_GEM_VERSION="~> 4.0"
       RUBY_VER=2.1.9
       RAKE_TASK=test_languageserver

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,13 @@ env:
     - PUPPET_GEM_VERSION="~> 4.0"
       RUBY_VER=2.1.9
       RAKE_TASK=test_languageserver
-    # Latest Puppet
+    # Latest 5.x puppet
     - PUPPET_GEM_VERSION="~> 5.0"
       RUBY_VER=2.4.1
+      RAKE_TASK=test_languageserver
+    # Latest Puppet
+    - PUPPET_GEM_VERSION="~> 6.0"
+      RUBY_VER=2.5.1
       RAKE_TASK=test_languageserver
     # Specific Puppet version testing
     - PUPPET_GEM_VERSION="5.1.0"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A ruby based implementation of a [Language Server](https://github.com/Microsoft/
 
 * Ensure a modern ruby is installed (2.1+)
 
-  The editor services support Puppet 4.7.1 and above
+  The editor services support Puppet 4.10.12 and above
 
 * Clone this repository
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,11 +6,7 @@ init:
 environment:
   matrix:
   # Language Server testing
-  # LTS Agent
-  - PUPPET_GEM_VERSION: "~> 4.7.0"
-    RUBY_VER: 21-x64
-    RAKE_TASK: test_languageserver
-  # Latest 4.x branch
+  # Latest 4.x branch (Covers LTS too)
   - PUPPET_GEM_VERSION: "~> 4.0"
     RUBY_VER: 21-x64
     RAKE_TASK: test_languageserver

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,10 @@ environment:
   - PUPPET_GEM_VERSION: "~> 5.0"
     RUBY_VER: 24-x64
     RAKE_TASK: test_languageserver
+  # Latest Puppet
+  - PUPPET_GEM_VERSION: "~> 6.0"
+    RUBY_VER: 25-x64
+    RAKE_TASK: test_languageserver
   # Specific Puppet version testing
   - PUPPET_GEM_VERSION: "5.1.0"
     RUBY_VER: 24-x64

--- a/lib/puppet-languageserver/puppet_helper.rb
+++ b/lib/puppet-languageserver/puppet_helper.rb
@@ -295,7 +295,7 @@ module PuppetLanguageServer
       @inmemory_cache.set(absolute_name, :type, nil)
       unless autoloader.loaded?(name)
         # This is an expensive call
-        unless autoloader.load(name)
+        unless autoloader.load(name, env)
           PuppetLanguageServer.log_message(:error, "[PuppetHelper::load_type_file] type #{absolute_name} did not load")
         end
       end
@@ -342,7 +342,12 @@ module PuppetLanguageServer
       type_count = 0
 
       # This is an expensive call
-      autoloader.files_to_load.each do |file|
+      if autoloader.method(:files_to_load).arity.zero?
+        params = []
+      else
+        params = [current_env]
+      end
+      autoloader.files_to_load(*params).each do |file|
         name = file.gsub(autoloader.path + '/', '')
         begin
           type_count += load_type_file(name, autoloader, current_env)

--- a/lib/puppet-languageserver/puppet_monkey_patches.rb
+++ b/lib/puppet-languageserver/puppet_monkey_patches.rb
@@ -18,7 +18,29 @@ module Puppet
             :source => caller.absolute_path,
             :line   => caller.lineno - 1, # Convert to a zero based line number system
           }
+          monkey_append_function_info(name, result)
+
           result
+        end
+
+        def monkey_clear_function_info
+          @monkey_function_list = {}
+        end
+
+        def monkey_append_function_info(name, value)
+          @monkey_function_list = {} if @monkey_function_list.nil?
+          @monkey_function_list[name] = {
+            :arity           => value[:arity],
+            :name            => value[:name],
+            :type            => value[:type],
+            :doc             => value[:doc],
+            :source_location => value[:source_location]
+          }
+        end
+
+        def monkey_function_list
+          @monkey_function_list = {} if @monkey_function_list.nil?
+          @monkey_function_list.clone
         end
       end
     end


### PR DESCRIPTION
The Language Server was broken for Puppet 6.  This PR updates the language server for Puppet 6 support, while still supporting Puppet 4 and 5.

This PR also adds Puppet 6 to the testing matrix.

Fixes #54 