### PR TITLE
(maint) Prepare for 0.15.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,17 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Unreleased
 
+## 0.15.0 - 2018-08-18
+
+### Added
+
 - ([GH-56](https://github.com/lingua-pupuli/puppet-editor-services/issues/56)) Add DocumentSymbol Support
+- ([GH-40](https://github.com/lingua-pupuli/puppet-editor-services/issues/40)) Add Sidecar process for the Language Server
+
+### Fixed
+
+- ([GH-54](https://github.com/lingua-pupuli/puppet-editor-services/issues/54)) Support Puppet 6 in the Language Server
+- ([GH-51](https://github.com/lingua-pupuli/puppet-editor-services/issues/51)) Fixed handling of errors during class loading
 
 ## 0.14.0 - 2018-08-17
 

--- a/lib/puppet-editor-services/version.rb
+++ b/lib/puppet-editor-services/version.rb
@@ -1,5 +1,5 @@
 module PuppetEditorServices
-  PUPPETEDITORSERVICESVERSION = '0.14.0'.freeze unless defined? PUPPETEDITORSERVICESVERSION
+  PUPPETEDITORSERVICESVERSION = '0.15.0'.freeze unless defined? PUPPETEDITORSERVICESVERSION
 
   # @api public
   #


### PR DESCRIPTION
This commit prepares for a version 0.15.0 release.

https://github.com/lingua-pupuli/puppet-editor-services/compare/0.14.0...master