### PR TITLE
(GH-55) Disable the Debug Server on Puppet 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,15 @@ matrix:
 env:
   matrix:
     # Language Server testing
-    # Latest 4.x branch (Covers LTS too)
+    # Latest 4.x Puppet (Covers LTS too)
     - PUPPET_GEM_VERSION="~> 4.0"
       RUBY_VER=2.1.9
       RAKE_TASK=test_languageserver
-    # Latest 5.x puppet
+    # Latest 5.x Puppet
     - PUPPET_GEM_VERSION="~> 5.0"
       RUBY_VER=2.4.1
       RAKE_TASK=test_languageserver
-    # Latest Puppet
+    # Latest 6.x Puppet
     - PUPPET_GEM_VERSION="~> 6.0"
       RUBY_VER=2.5.1
       RAKE_TASK=test_languageserver
@@ -32,7 +32,7 @@ env:
       RAKE_TASK=test_languageserver
 
     # Language Server Sidecar testing
-    # Latest 4.x branch (Covers LTS too)
+    # Latest 4.x Puppet (Covers LTS too)
     - PUPPET_GEM_VERSION="~> 4.0"
       RUBY_VER=2.1.9
       RAKE_TASK=test_languageserver_sidecar
@@ -40,23 +40,23 @@ env:
     - PUPPET_GEM_VERSION="~> 5.0"
       RUBY_VER=2.4.1
       RAKE_TASK=test_languageserver_sidecar
-    # Latest Puppet
+    # Latest 6.x Puppet
     - PUPPET_GEM_VERSION="~> 6.0"
       RUBY_VER=2.5.1
       RAKE_TASK=test_languageserver_sidecar
 
     # Debug Server testing
-    # LTS Agent
-    - PUPPET_GEM_VERSION="~> 4.7.0"
-      RUBY_VER=2.1.9
-      RAKE_TASK=test_debugserver
-    # Latest 4.x branch
+    # Latest 4.x Puppet (Covers LTS too)
     - PUPPET_GEM_VERSION="~> 4.0"
       RUBY_VER=2.1.9
       RAKE_TASK=test_debugserver
-    # Latest Puppet
+    # Latest 5.x Puppet
     - PUPPET_GEM_VERSION="~> 5.0"
       RUBY_VER=2.4.1
+      RAKE_TASK=test_debugserver
+    # Latest 6.x Puppet
+    - PUPPET_GEM_VERSION="~> 6.0"
+      RUBY_VER=2.5.1
       RAKE_TASK=test_debugserver
 
     # Ruby style

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,56 +13,28 @@ matrix:
 
 env:
   matrix:
-    # Language Server testing
     # Latest 4.x Puppet (Covers LTS too)
     - PUPPET_GEM_VERSION="~> 4.0"
       RUBY_VER=2.1.9
-      RAKE_TASK=test_languageserver
+      RAKE_TASK="test_languageserver test_languageserver_sidecar test_debugserver"
     # Latest 5.x Puppet
     - PUPPET_GEM_VERSION="~> 5.0"
       RUBY_VER=2.4.1
-      RAKE_TASK=test_languageserver
+      RAKE_TASK="test_languageserver test_languageserver_sidecar test_debugserver"
     # Latest 6.x Puppet
     - PUPPET_GEM_VERSION="~> 6.0"
       RUBY_VER=2.5.1
-      RAKE_TASK=test_languageserver
+      RAKE_TASK="test_languageserver test_languageserver_sidecar test_debugserver"
+
     # Specific Puppet version testing
     - PUPPET_GEM_VERSION="5.1.0"
       RUBY_VER=2.4.1
-      RAKE_TASK=test_languageserver
+      RAKE_TASK="test_languageserver"
 
-    # Language Server Sidecar testing
-    # Latest 4.x Puppet (Covers LTS too)
-    - PUPPET_GEM_VERSION="~> 4.0"
-      RUBY_VER=2.1.9
-      RAKE_TASK=test_languageserver_sidecar
-    # Latest 5.x puppet
-    - PUPPET_GEM_VERSION="~> 5.0"
-      RUBY_VER=2.4.1
-      RAKE_TASK=test_languageserver_sidecar
-    # Latest 6.x Puppet
-    - PUPPET_GEM_VERSION="~> 6.0"
+    # Ruby tasks (style).  Puppet version is irrelevant
+    - PUPPET_GEM_VERSION="> 0.0"
       RUBY_VER=2.5.1
-      RAKE_TASK=test_languageserver_sidecar
-
-    # Debug Server testing
-    # Latest 4.x Puppet (Covers LTS too)
-    - PUPPET_GEM_VERSION="~> 4.0"
-      RUBY_VER=2.1.9
-      RAKE_TASK=test_debugserver
-    # Latest 5.x Puppet
-    - PUPPET_GEM_VERSION="~> 5.0"
-      RUBY_VER=2.4.1
-      RAKE_TASK=test_debugserver
-    # Latest 6.x Puppet
-    - PUPPET_GEM_VERSION="~> 6.0"
-      RUBY_VER=2.5.1
-      RAKE_TASK=test_debugserver
-
-    # Ruby style
-    - PUPPET_GEM_VERSION="~> 4.0"
-      RUBY_VER=2.4.1
-      RAKE_TASK=rubocop
+      RAKE_TASK="rubocop"
 
 before_install: true
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,61 +5,30 @@ init:
 
 environment:
   matrix:
-  # Language Server testing
   # Latest 4.x Puppet (Covers LTS too)
   - PUPPET_GEM_VERSION: "~> 4.0"
     RUBY_VER: 21-x64
-    RAKE_TASK: test_languageserver
+    RAKE_TASK: "test_languageserver test_languageserver_sidecar test_debugserver"
+
   # Latest 5.x Puppet
   - PUPPET_GEM_VERSION: "~> 5.0"
     RUBY_VER: 24-x64
-    RAKE_TASK: test_languageserver
+    RAKE_TASK: "test_languageserver test_languageserver_sidecar test_debugserver"
+
   # Latest 6.x Puppet
   - PUPPET_GEM_VERSION: "~> 6.0"
     RUBY_VER: 25-x64
-    RAKE_TASK: test_languageserver
-  # Specific Puppet version testing
+    RAKE_TASK: "test_languageserver test_languageserver_sidecar test_debugserver"
+
+    # Specific Puppet version testing
   - PUPPET_GEM_VERSION: "5.1.0"
     RUBY_VER: 24-x64
     RAKE_TASK: test_languageserver
 
-  # Language Server Sidecar testing
-  # Latest 4.x Puppet (Covers LTS too)
-  - PUPPET_GEM_VERSION: "~> 4.0"
-    RUBY_VER: 21-x64
-    RAKE_TASK: test_languageserver_sidecar
-  # Latest 5.x Puppet
-  - PUPPET_GEM_VERSION: "~> 5.0"
-    RUBY_VER: 24-x64
-    RAKE_TASK: test_languageserver_sidecar
-  # Latest 6.x Puppet
-  - PUPPET_GEM_VERSION: "~> 6.0"
+    # Ruby tasks (style, build release archives)
+  - PUPPET_GEM_VERSION: "> 0.0" # Version is irrelevant
     RUBY_VER: 25-x64
-    RAKE_TASK: test_languageserver_sidecar
-
-  # Debug Server testing
-  # Latest 4.x Puppet (Covers LTS too)
-  - PUPPET_GEM_VERSION: "~> 4.0"
-    RUBY_VER: 21-x64
-    RAKE_TASK: test_debugserver
-  # Latest 5.x Puppet
-  - PUPPET_GEM_VERSION: "~> 5.0"
-    RUBY_VER: 24-x64
-    RAKE_TASK: test_debugserver
-  # Latest 6.x Puppet
-  - PUPPET_GEM_VERSION: "~> 6.0"
-    RUBY_VER: 24-x64
-    RAKE_TASK: test_debugserver
-
-  # Ruby style
-  - PUPPET_GEM_VERSION: "~> 4.0"
-    RUBY_VER: 23-x64
-    RAKE_TASK: rubocop
-
-  # Build release archives
-  - PUPPET_GEM_VERSION: "~> 4.0"
-    RUBY_VER: 23-x64
-    RAKE_TASK: build
+    RAKE_TASK: rubocop build
 
 matrix:
   fast_finish: true
@@ -88,7 +57,7 @@ install:
 build: off
 
 test_script:
-- cmd: IF NOT [%RAKE_TASK%] == [] bundle exec rake %RAKE_TASK%
+- cmd: IF NOT "%RAKE_TASK%" == "" bundle exec rake %RAKE_TASK%
 
 artifacts:
   - path: output/*.*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,15 +6,15 @@ init:
 environment:
   matrix:
   # Language Server testing
-  # Latest 4.x branch (Covers LTS too)
+  # Latest 4.x Puppet (Covers LTS too)
   - PUPPET_GEM_VERSION: "~> 4.0"
     RUBY_VER: 21-x64
     RAKE_TASK: test_languageserver
-  # Latest Puppet
+  # Latest 5.x Puppet
   - PUPPET_GEM_VERSION: "~> 5.0"
     RUBY_VER: 24-x64
     RAKE_TASK: test_languageserver
-  # Latest Puppet
+  # Latest 6.x Puppet
   - PUPPET_GEM_VERSION: "~> 6.0"
     RUBY_VER: 25-x64
     RAKE_TASK: test_languageserver
@@ -24,30 +24,30 @@ environment:
     RAKE_TASK: test_languageserver
 
   # Language Server Sidecar testing
-  # Latest 4.x branch (Covers LTS too)
+  # Latest 4.x Puppet (Covers LTS too)
   - PUPPET_GEM_VERSION: "~> 4.0"
     RUBY_VER: 21-x64
     RAKE_TASK: test_languageserver_sidecar
-  # Latest Puppet
+  # Latest 5.x Puppet
   - PUPPET_GEM_VERSION: "~> 5.0"
     RUBY_VER: 24-x64
     RAKE_TASK: test_languageserver_sidecar
-  # Latest Puppet
+  # Latest 6.x Puppet
   - PUPPET_GEM_VERSION: "~> 6.0"
     RUBY_VER: 25-x64
     RAKE_TASK: test_languageserver_sidecar
 
   # Debug Server testing
-  # LTS Agent
-  - PUPPET_GEM_VERSION: "~> 4.7.0"
-    RUBY_VER: 21-x64
-    RAKE_TASK: test_debugserver
-  # Latest 4.x branch
+  # Latest 4.x Puppet (Covers LTS too)
   - PUPPET_GEM_VERSION: "~> 4.0"
     RUBY_VER: 21-x64
     RAKE_TASK: test_debugserver
-  # Latest Puppet
+  # Latest 5.x Puppet
   - PUPPET_GEM_VERSION: "~> 5.0"
+    RUBY_VER: 24-x64
+    RAKE_TASK: test_debugserver
+  # Latest 6.x Puppet
+  - PUPPET_GEM_VERSION: "~> 6.0"
     RUBY_VER: 24-x64
     RAKE_TASK: test_debugserver
 

--- a/lib/puppet-debugserver/puppet_debug_session.rb
+++ b/lib/puppet-debugserver/puppet_debug_session.rb
@@ -479,7 +479,7 @@ module PuppetDebugServer
       # Send experimental warning
       PuppetDebugServer::PuppetDebugSession.connection.send_output_event(
         'category' => 'console',
-        'output' => "**************************************************\n* The Puppet debugger is an experimental feature *\n* Debug Server v#{PuppetEditorServices.version}                            *\n**************************************************\n\n"
+        'output' => "**************************************************\n* The Puppet debugger is an experimental feature *\n* Debug Server v#{PuppetEditorServices.version}                           *\n**************************************************\n\n"
       )
 
       if Gem::Version.new(Puppet.version) >= Gem::Version.new('6.0.0')

--- a/lib/puppet-debugserver/puppet_debug_session.rb
+++ b/lib/puppet-debugserver/puppet_debug_session.rb
@@ -482,11 +482,19 @@ module PuppetDebugServer
         'output' => "**************************************************\n* The Puppet debugger is an experimental feature *\n* Debug Server v#{PuppetEditorServices.version}                            *\n**************************************************\n\n"
       )
 
-      PuppetDebugServer::PuppetDebugSession.connection.send_output_event(
-        'category' => 'console',
-        'output'   => 'puppet ' + cmd_args.join(' ') + "\n"
-      )
-      Puppet::Util::CommandLine.new('puppet.rb', cmd_args).execute
+      if Gem::Version.new(Puppet.version) >= Gem::Version.new('6.0.0')
+        # Puppet Debug Server isn't supported on Puppet 6 yet
+        PuppetDebugServer::PuppetDebugSession.connection.send_output_event(
+          'category' => 'console',
+          'output' => "The Puppet debugger is not supported on Puppet #{Puppet.version}. Version 4.x and 5.x are supported.\n"
+        )
+      else
+        PuppetDebugServer::PuppetDebugSession.connection.send_output_event(
+          'category' => 'console',
+          'output'   => 'puppet ' + cmd_args.join(' ') + "\n"
+        )
+        Puppet::Util::CommandLine.new('puppet.rb', cmd_args).execute
+      end
     end
 
     class SourcePosition

--- a/spec/debugserver/integration/puppet-debugserver/end_to_end_spec.rb
+++ b/spec/debugserver/integration/puppet-debugserver/end_to_end_spec.rb
@@ -37,6 +37,7 @@ describe 'End to End Testing' do
     let(:args) { [] }
 
     it 'should process the manifest and exit with 0' do
+      skip("Puppet 6 is not supported") if Gem::Version.new(Puppet.version) >= Gem::Version.new('6.0.0')
       # initialize_request
       @client.send_data(initialize_request(@client.next_seq_id))
       expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
@@ -65,6 +66,7 @@ describe 'End to End Testing' do
     let(:args) { [] }
 
     it 'should process the manifest and exit with 1' do
+      skip("Puppet 6 is not supported") if Gem::Version.new(Puppet.version) >= Gem::Version.new('6.0.0')
       # initialize_request
       @client.send_data(initialize_request(@client.next_seq_id))
       expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
@@ -138,6 +140,7 @@ describe 'End to End Testing' do
     # - Launch request can occur during init
 
     it 'should process the manifest and exit with 0' do
+      skip("Puppet 6 is not supported") if Gem::Version.new(Puppet.version) >= Gem::Version.new('6.0.0')
       # initialize_request
       @client.send_data(initialize_request(@client.next_seq_id))
       expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])


### PR DESCRIPTION
The Debug Server is currently broken when using Puppet 6.  While the work to
enable the Debug Server is being undertaken, this commit adds a check which
terminates the Debug Server gracefully if it is detected on Puppet 6.  This
commit also updates the end-to-end tests to skip testing on Puppet 6.

---

Previously the Debug Server did not tests on the newly released Puppet 6.  This
commit adds Puppet 6 to the testing matrix of the Debug Server.

This commit also cleans up the Travis and Appveyor comments to be mataching and
more concise.

---

Previously each testing combination was tested in isolation.  However this meant
bundler was being called multiple times for no reasone.  Also while the
Appveyor test runtimes are quite low, because there are so many cells there's a
large delay in the Appveyor suite.  This commit refactors the Travis and
Appveyor files to test as much as possible for each Ruby/Puppet combination.
There is no loss of test coverage, just the ordering is different.

