### PR TITLE
(GH-69) Pin rubocop to < 0.60.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,8 @@ group :development do
   if RUBY_VERSION =~ /^2\.1\./
     gem "rubocop", "<= 0.57.2", :require => false, :platforms => [:ruby, :x64_mingw]
   else
-    gem "rubocop",              :require => false, :platforms => [:ruby, :x64_mingw]
+    # v0.60.0 brought in many violations.  For now pin this
+    gem "rubocop", "< 0.60.0", :require => false, :platforms => [:ruby, :x64_mingw]
   end
 
   if ENV['PUPPET_GEM_VERSION']


### PR DESCRIPTION
Rubocop has released 0.60.0 however it's "broken" some of the cops in our
project. In particular the Layout/AlignHash cop.  This commit pins Rubocop to
the a version prior to 0.60.0 to allow work to continue, while the violations
are fixed.
