### PR TITLE
(GH-67) Make resource completion smarter

### DIFF
--- a/lib/puppet-languageserver-sidecar/sidecar_protocol_extensions.rb
+++ b/lib/puppet-languageserver-sidecar/sidecar_protocol_extensions.rb
@@ -55,6 +55,7 @@ module PuppetLanguageServerSidecar
             :doc  => attrclass.doc
           }
           val[:required?] = attrclass.required? if attrclass.respond_to?(:required?)
+          val[:isnamevar?] = attrclass.required? if attrclass.respond_to?(:isnamevar?)
           obj.attributes[attrname] = val
         end
         obj

--- a/lib/puppet-languageserver/sidecar_protocol.rb
+++ b/lib/puppet-languageserver/sidecar_protocol.rb
@@ -179,9 +179,10 @@ module PuppetLanguageServer
           unless value['attributes'].nil?
             value['attributes'].each do |attr_name, obj_attr|
               attributes[attr_name.intern] = {
-                :type      => obj_attr['type'].intern,
-                :doc       => obj_attr['doc'],
-                :required? => obj_attr['required?']
+                :type       => obj_attr['type'].intern,
+                :doc        => obj_attr['doc'],
+                :required?  => obj_attr['required?'],
+                :isnamevar? => obj_attr['isnamevar?']
               }
             end
           end

--- a/spec/languageserver/integration/puppet-languageserver/manifest/completion_provider_spec.rb
+++ b/spec/languageserver/integration/puppet-languageserver/manifest/completion_provider_spec.rb
@@ -4,6 +4,35 @@ def number_of_completion_item_with_type(completion_list, typename)
   (completion_list['items'].select { |item| item['data']['type'] == typename}).length
 end
 
+def create_mock_resource(parameters = [], properties = [])
+  object = PuppetLanguageServer::PuppetHelper::PuppetType.new
+  object.doc = 'mock documentation'
+  object.attributes = {}
+  parameters.each { |name| object.attributes[name] = {
+    :type        => :param,
+    :doc         => 'mock parameter doc',
+    :required? => nil,
+    :isnamevar?  => nil
+  }}
+  properties.each { |name| object.attributes[name] = {
+    :type        => :property,
+    :doc         => 'mock parameter doc',
+    :required? => nil,
+    :isnamevar?  => nil
+  }}
+
+  object
+end
+
+def create_ensurable_property
+  {
+    :type        => :property,
+    :doc         => 'mock ensure doc',
+    :required? => nil,
+    :isnamevar?  => nil
+  }
+end
+
 describe 'completion_provider' do
   let(:subject) { PuppetLanguageServer::Manifest::CompletionProvider }
   let(:nil_response) { LanguageServer::CompletionList.create_nil_response }
@@ -281,6 +310,21 @@ EOT
         @completion_response = subject.complete(content, line_num, char_num)
       end
 
+      context 'for an unknown keyword' do
+        before(:each) do
+          @resolve_request = @completion_response["items"].find do |item|
+            item["label"] == 'class' && item["kind"] == LanguageServer::COMPLETIONITEMKIND_KEYWORD
+          end
+          raise RuntimeError, "The keyword class response could not be found" if @resolve_request.nil?
+        end
+
+        it 'should return the original request' do
+          @resolve_request['data']['name'] = 'keyword_not_found'
+          result = subject.resolve(@resolve_request)
+          expect(result).to eq(@resolve_request)
+        end
+      end
+
       %w[class define].each do |testcase|
         context "for #{testcase}" do
           before(:each) do
@@ -343,16 +387,22 @@ EOT
       before(:each) do
         # Generate the resolution request based on a completion response
         @completion_response = subject.complete(content, line_num, char_num)
+
+        @resolve_request = @completion_response["items"].find do |item|
+          item["label"] == 'alert' && item["kind"] == LanguageServer::COMPLETIONITEMKIND_FUNCTION
+        end
+        raise RuntimeError, "alert function could not be found" if @resolve_request.nil?
+      end
+
+      context 'for an unknown function' do
+        it 'should return the original request' do
+          @resolve_request['data']['name'] = 'function_not_found'
+          result = subject.resolve(@resolve_request)
+          expect(result).to eq(@resolve_request)
+        end
       end
 
       context 'for a well known function (alert)' do
-        before(:each) do
-          @resolve_request = @completion_response["items"].find do |item|
-            item["label"] == 'alert' && item["kind"] == LanguageServer::COMPLETIONITEMKIND_FUNCTION
-          end
-          raise RuntimeError, "alert function could not be found" if @resolve_request.nil?
-        end
-
         it 'should return the documentation' do
           result = subject.resolve(@resolve_request)
           expect(result['documentation']).to match(/.+/)
@@ -374,20 +424,27 @@ EOT
       }
       let(:line_num) { 0 }
       let(:char_num) { 0 }
+      let(:mock_resource) { create_mock_resource([:param1, :param2], [:prop1, :prop2]) }
 
       before(:each) do
         # Generate the resolution request based on a completion response
         @completion_response = subject.complete(content, line_num, char_num)
+
+        @resolve_request = @completion_response["items"].find do |item|
+          item["label"] == 'user' && item["kind"] == LanguageServer::COMPLETIONITEMKIND_MODULE
+        end
+        raise RuntimeError, "user type could not be found" if @resolve_request.nil?
+      end
+
+      context 'for an unknown puppet type' do
+        it 'should return the original request' do
+          expect(PuppetLanguageServer::PuppetHelper).to receive(:get_type).and_return(nil)
+          result = subject.resolve(@resolve_request)
+          expect(result).to eq(@resolve_request)
+        end
       end
 
       context 'for a well known puppet type (user)' do
-        before(:each) do
-          @resolve_request = @completion_response["items"].find do |item|
-            item["label"] == 'user' && item["kind"] == LanguageServer::COMPLETIONITEMKIND_MODULE
-          end
-          raise RuntimeError, "user type could not be found" if @resolve_request.nil?
-        end
-
         it 'should return the documentation' do
           result = subject.resolve(@resolve_request)
           expect(result['documentation']).to match(/.+/)
@@ -396,6 +453,55 @@ EOT
         it 'should return a text snippet' do
           result = subject.resolve(@resolve_request)
           expect(result['insertText']).to match(/.+/)
+          expect(result['insertTextFormat']).to eq(LanguageServer::INSERTTEXTFORMAT_SNIPPET)
+        end
+      end
+
+      context 'for a non-ensurable puppet type with no required attributes' do
+        it 'should not return any parameters or properties in the snippet' do
+          expect(PuppetLanguageServer::PuppetHelper).to receive(:get_type).and_return(mock_resource)
+          result = subject.resolve(@resolve_request)
+          expect(result['insertText']).to_not match(/param1/)
+          expect(result['insertText']).to_not match(/param2/)
+          expect(result['insertText']).to_not match(/prop1/)
+          expect(result['insertText']).to_not match(/prop2/)
+          expect(result['insertText']).to_not match(/ensure/)
+          expect(result['insertTextFormat']).to eq(LanguageServer::INSERTTEXTFORMAT_SNIPPET)
+        end
+      end
+
+      context 'for an ensurable puppet type with no required attributes' do
+        it 'should only return the ensure property' do
+          mock_resource.attributes[:ensure] = create_ensurable_property
+          expect(PuppetLanguageServer::PuppetHelper).to receive(:get_type).and_return(mock_resource)
+
+          result = subject.resolve(@resolve_request)
+          expect(result['insertText']).to_not match(/param1/)
+          expect(result['insertText']).to_not match(/param2/)
+          expect(result['insertText']).to_not match(/prop1/)
+          expect(result['insertText']).to_not match(/prop2/)
+          expect(result['insertText']).to match(/ensure/)
+          expect(result['insertTextFormat']).to eq(LanguageServer::INSERTTEXTFORMAT_SNIPPET)
+        end
+      end
+
+      context 'for an ensurable puppet type with required attributes, and namevars' do
+        it 'should only the ensure property' do
+          mock_resource.attributes[:ensure] = create_ensurable_property
+          mock_resource.attributes[:param1][:required?] = true
+          mock_resource.attributes[:param1][:isnamevar?] = true
+          mock_resource.attributes[:param2][:required?] = true
+          mock_resource.attributes[:prop1][:required?] = true
+          mock_resource.attributes[:prop2][:required?] = true
+          mock_resource.attributes[:prop2][:isnamevar?] = true
+          expect(PuppetLanguageServer::PuppetHelper).to receive(:get_type).and_return(mock_resource)
+
+          result = subject.resolve(@resolve_request)
+          expect(result['insertText']).to_not match(/param1/)
+          expect(result['insertText']).to match(/param2/)
+          expect(result['insertText']).to match(/prop1/)
+          expect(result['insertText']).to_not match(/prop2/)
+          expect(result['insertText']).to match(/ensure/)
           expect(result['insertTextFormat']).to eq(LanguageServer::INSERTTEXTFORMAT_SNIPPET)
         end
       end
@@ -414,16 +520,29 @@ EOT
       before(:each) do
         # Generate the resolution request based on a completion response
         @completion_response = subject.complete(content, line_num, char_num)
+        @resolve_request = @completion_response["items"].find do |item|
+          item["label"] == 'name' && item["kind"] == LanguageServer::COMPLETIONITEMKIND_PROPERTY
+        end
+        raise RuntimeError, "name parameter could not be found" if @resolve_request.nil?
+      end
+
+      context 'for an unknown type' do
+        it 'should return the original request' do
+          @resolve_request['data']['resource_type'] = 'resource_not_found'
+          result = subject.resolve(@resolve_request)
+          expect(result).to eq(@resolve_request)
+        end
+      end
+
+      context 'for an unknown parameter' do
+        it 'should return the original request' do
+          @resolve_request['data']['param'] = 'param_not_found'
+          result = subject.resolve(@resolve_request)
+          expect(result).to eq(@resolve_request)
+        end
       end
 
       context 'for the name parameter of a well known puppet type (user)' do
-        before(:each) do
-          @resolve_request = @completion_response["items"].find do |item|
-            item["label"] == 'name' && item["kind"] == LanguageServer::COMPLETIONITEMKIND_PROPERTY
-          end
-          raise RuntimeError, "name parameter could not be found" if @resolve_request.nil?
-        end
-
         it 'should return the documentation' do
           result = subject.resolve(@resolve_request)
           expect(result['documentation']).to match(/.+/)
@@ -450,16 +569,29 @@ EOT
       before(:each) do
         # Generate the resolution request based on a completion response
         @completion_response = subject.complete(content, line_num, char_num)
+        @resolve_request = @completion_response["items"].find do |item|
+          item["label"] == 'ensure' && item["kind"] == LanguageServer::COMPLETIONITEMKIND_PROPERTY
+        end
+        raise RuntimeError, "ensure property could not be found" if @resolve_request.nil?
+      end
+
+      context 'for an unknown type' do
+        it 'should return the original request' do
+          @resolve_request['data']['resource_type'] = 'resource_not_found'
+          result = subject.resolve(@resolve_request)
+          expect(result).to eq(@resolve_request)
+        end
+      end
+
+      context 'for an unknown property' do
+        it 'should return the original request' do
+          @resolve_request['data']['prop'] = 'prop_not_found'
+          result = subject.resolve(@resolve_request)
+          expect(result).to eq(@resolve_request)
+        end
       end
 
       context 'for the ensure property of a well known puppet type (user)' do
-        before(:each) do
-          @resolve_request = @completion_response["items"].find do |item|
-            item["label"] == 'ensure' && item["kind"] == LanguageServer::COMPLETIONITEMKIND_PROPERTY
-          end
-          raise RuntimeError, "ensure property could not be found" if @resolve_request.nil?
-        end
-
         it 'should return the documentation' do
           result = subject.resolve(@resolve_request)
           expect(result['documentation']).to match(/.+/)

--- a/spec/languageserver/spec_helper.rb
+++ b/spec/languageserver/spec_helper.rb
@@ -83,8 +83,8 @@ def random_sidecar_puppet_type
   result = add_random_basepuppetobject_values!(PuppetLanguageServer::Sidecar::Protocol::PuppetType.new())
   result.doc = 'doc' + rand(1000).to_s
   result.attributes = {
-    :attr_name1 => { :type => :attr_type, :doc => 'attr_doc1', :required? => false },
-    :attr_name2 => { :type => :attr_type, :doc => 'attr_doc2', :required? => false }
+    :attr_name1 => { :type => :attr_type, :doc => 'attr_doc1', :required? => false, :isnamevar? => true },
+    :attr_name2 => { :type => :attr_type, :doc => 'attr_doc2', :required? => false, :isnamevar? => false }
   }
   result
 end

--- a/spec/languageserver/unit/puppet-languageserver/sidecar_protocol_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/sidecar_protocol_spec.rb
@@ -235,8 +235,8 @@ describe 'PuppetLanguageServer::Sidecar::Protocol' do
       value = subject_klass.new
       value.doc = 'doc'
       value.attributes = {
-        :attr_name1 => { :type => :attr_type, :doc => 'attr_doc1', :required? => false },
-        :attr_name2 => { :type => :attr_type, :doc => 'attr_doc2', :required? => false }
+        :attr_name1 => { :type => :attr_type, :doc => 'attr_doc1', :required? => false, :isnamevar? => false },
+        :attr_name2 => { :type => :attr_type, :doc => 'attr_doc2', :required? => false, :isnamevar? => true }
       }
       add_default_basepuppetobject_values!(value)
     }


### PR DESCRIPTION
Previously when a completion resolution request was received for a resource it
was hardcoded to return the name and ensure property.  However not all resources
are ensurable, and some resources have other required properties or parameters.
This commit changes the resource completion to interrogate the Puppet Type and
then generate a more appropriate code snippet;

* The sidecar was extended to also track the isnamevar? value for resource
  properties and parameters. This was needed by the completion resolver as
  namevars should not appear in the code snippet as they come from the resource
  name.

  This also required tests to changed for this new property in the sidecar
  protocol.

* The resource_type completion request was modified to dynamically generate the
  snippet for resources;
  - If the resource is ensurable, then the ensure parameter now appears the
    first in the list, as per puppet-lint
  - Properties/Parameters which are marked as required, are included in the code
    snippet, except for those marked as a namevars.  They implicitly come from
    the resource name.
  - The resource property/param names are sorted in alphabetical order (except
    for ensure) as per puppet-lint
  - The hash rockets of the generated snippet are now aligned as per puppet-lint

* Added tests for the new rsource completion style

* Fixed a minor bug which really only shoed itself during testing and wouldn't
  normally be an issue in normal operation.  The object being passed into the
  `resolve` was being mutated inside the method.  However the intended behaviour
  of the method was output a new object and modify the input object in any way.
  This commit instead clones the input object very early and then uses the clone
  internally.

Fixes #67 
