### PR TITLE
(GH-68) Load workspace information on initial start and on document saving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 - ([GH-75](https://github.com/lingua-pupuli/puppet-editor-services/issues/75)) Add a node completion item snippet
 - ([GH-34](https://github.com/lingua-pupuli/puppet-editor-services/issues/34)) Autocomplete and hover should retrieve defined types and classes
+- ([GH-68](https://github.com/lingua-pupuli/puppet-editor-services/issues/68)) Language Server should evaluate the locally edited workspace
 
 ## 0.15.1 - 2018-10-30
 

--- a/lib/puppet-languageserver/document_store.rb
+++ b/lib/puppet-languageserver/document_store.rb
@@ -61,7 +61,6 @@ module PuppetLanguageServer
       }
     end
 
-    # This method is mainly used for testin. It expires the cache
     def self.expire_store_information
       @doc_mutex.synchronize do
         @workspace_info_cache[:expires] = Time.new - 120

--- a/lib/puppet-languageserver/message_router.rb
+++ b/lib/puppet-languageserver/message_router.rb
@@ -204,6 +204,15 @@ module PuppetLanguageServer
 
       when 'textDocument/didSave'
         PuppetLanguageServer.log_message(:info, 'Received textDocument/didSave notification.')
+        # Expire the store cache so that the store information can re-evaluated
+        PuppetLanguageServer::DocumentStore.expire_store_information
+        if PuppetLanguageServer::DocumentStore.store_has_module_metadata?
+          # Load the workspace information
+          PuppetLanguageServer::PuppetHelper.load_workspace_async
+        else
+          # Purge the workspace information
+          PuppetLanguageServer::PuppetHelper.purge_workspace
+        end
 
       else
         PuppetLanguageServer.log_message(:error, "Unknown RPC notification #{method}")

--- a/lib/puppet-languageserver/puppet_helper.rb
+++ b/lib/puppet-languageserver/puppet_helper.rb
@@ -167,6 +167,35 @@ module PuppetLanguageServer
       @inmemory_cache
     end
 
+    # Workspace Loading
+    def self.load_workspace_async
+      load_workspace_classes_async
+      load_workspace_functions_async
+      load_workspace_types_async
+      true
+    end
+
+    def self.load_workspace_classes_async
+      return if PuppetLanguageServer::DocumentStore.store_root_path.nil?
+      sidecar_queue.enqueue('workspace_classes', ['--local-workspace', PuppetLanguageServer::DocumentStore.store_root_path])
+    end
+
+    def self.load_workspace_functions_async
+      return if PuppetLanguageServer::DocumentStore.store_root_path.nil?
+      sidecar_queue.enqueue('workspace_functions', ['--local-workspace', PuppetLanguageServer::DocumentStore.store_root_path])
+    end
+
+    def self.load_workspace_types_async
+      return if PuppetLanguageServer::DocumentStore.store_root_path.nil?
+      sidecar_queue.enqueue('workspace_types', ['--local-workspace', PuppetLanguageServer::DocumentStore.store_root_path])
+    end
+
+    def self.purge_workspace
+      PuppetLanguageServer::PuppetHelper.cache.import_sidecar_list!([], :class, :workspace)
+      PuppetLanguageServer::PuppetHelper.cache.import_sidecar_list!([], :function, :workspace)
+      PuppetLanguageServer::PuppetHelper.cache.import_sidecar_list!([], :type, :workspace)
+    end
+
     def self.sidecar_queue
       @sidecar_queue_obj ||= PuppetLanguageServer::SidecarQueue.new
     end

--- a/lib/puppet_languageserver.rb
+++ b/lib/puppet_languageserver.rb
@@ -164,6 +164,11 @@ module PuppetLanguageServer
 
       log_message(:info, 'Preloading Classes (Async)...')
       PuppetLanguageServer::PuppetHelper.load_default_classes_async
+
+      if PuppetLanguageServer::DocumentStore.store_has_module_metadata?
+        log_message(:info, 'Preloading Workspace (Async)...')
+        PuppetLanguageServer::PuppetHelper.load_workspace_async
+      end
     else
       log_message(:info, 'Skipping preloading Puppet')
     end


### PR DESCRIPTION
The Sidecar has the ability to process the active workspace for Puppet Type,
Class and Function information however this wasn't exposed in the Language
Server.  This commit;

* Modifies the Language Server loading to also queue up processing the workspace
  if the workspace is a module (has metadata.json)
* Modifies the message router to process the workspace when a Puppet file (.pp)
  is saved.  It will also remove any workspace classes, types and functions if
  the workspace is NOT a module.  This is needed if a user removes metadata.json
  during the editing session
* Also expires the document store cache on every file save to force the
  workspace to be re-evaluated on document save.  This should hopefully happen
  not too frequently, but still hopefully see changes to the workspace fast
  enough for the user experience to be good

- [x] Need to figure out when to clear the workspace cache (caching is hard!)
- [x] Need to test completion provider for workspace objects
- [x] Need to test hover provider for workspace objects
- [x] Need to test definition provider for workspace objects
- [x] Need to test document symbol provider for workspace objects
