### PR TITLE
(maint) Remove redundant code

### DIFF
--- a/lib/puppet-languageserver/sidecar_protocol.rb
+++ b/lib/puppet-languageserver/sidecar_protocol.rb
@@ -159,15 +159,8 @@ module PuppetLanguageServer
 
         def to_h
           super.to_h.merge(
-            'key'            => key,
-            'calling_source' => calling_source,
-            'source'         => source,
-            'line'           => line,
-            'char'           => char,
-            'length'         => length,
-
-            'doc'            => doc,
-            'attributes'     => attributes
+            'doc'        => doc,
+            'attributes' => attributes
           )
         end
 


### PR DESCRIPTION
The PuppetType serialiser needless set hash attributes that are set by the base
class. This commit removes the redundant code.