### PR TITLE
(GH-34) Parse class and defined type parameters 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## Unreleased
 
 - ([GH-75](https://github.com/lingua-pupuli/puppet-editor-services/issues/75)) Add a node completion item snippet
+- ([GH-34](https://github.com/lingua-pupuli/puppet-editor-services/issues/34)) Autocomplete and hover should retrieve defined types and classes
 
 ## 0.15.1 - 2018-10-30
 

--- a/lib/puppet-languageserver-sidecar/puppet_helper.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_helper.rb
@@ -212,12 +212,13 @@ module PuppetLanguageServerSidecar
             next
           end
           puppet_class['name']       = item.name
+          puppet_class['doc']        = nil
           puppet_class['parameters'] = item.parameters
           puppet_class['source']     = manifest_file
           puppet_class['line']       = result.locator.line_for_offset(item.offset) - 1
           puppet_class['char']       = result.locator.offset_on_line(item.offset)
 
-          obj = PuppetLanguageServerSidecar::Protocol::PuppetClass.from_puppet(item.name, puppet_class)
+          obj = PuppetLanguageServerSidecar::Protocol::PuppetClass.from_puppet(item.name, puppet_class, result.locator)
           class_info << obj
         end
       else
@@ -232,12 +233,12 @@ module PuppetLanguageServerSidecar
             next
           end
           puppet_class['name']       = item.name
+          puppet_class['doc']        = nil
           puppet_class['parameters'] = item.parameters
           puppet_class['source']     = manifest_file
           puppet_class['line']       = item.line
           puppet_class['char']       = item.pos
-
-          obj = PuppetLanguageServerSidecar::Protocol::PuppetClass.from_puppet(item.name, puppet_class)
+          obj = PuppetLanguageServerSidecar::Protocol::PuppetClass.from_puppet(item.name, puppet_class, item.locator)
           class_info << obj
         end
       end

--- a/lib/puppet-languageserver-sidecar/sidecar_protocol_extensions.rb
+++ b/lib/puppet-languageserver-sidecar/sidecar_protocol_extensions.rb
@@ -11,14 +11,25 @@ module PuppetLanguageServerSidecar
     end
 
     class PuppetClass < PuppetLanguageServer::Sidecar::Protocol::PuppetClass
-      def self.from_puppet(name, item)
+      def self.from_puppet(name, item, locator)
+        name = name.intern if name.is_a?(String)
         obj = PuppetLanguageServer::Sidecar::Protocol::PuppetClass.new
         obj.key            = name
+        obj.doc            = item['doc']
         obj.source         = item['source']
         obj.calling_source = obj.source
         obj.line           = item['line']
         obj.char           = item['char']
-        # TODO: Doc, parameters?
+        obj.parameters     = {}
+        item['parameters'].each do |param|
+          val = {
+            :type => nil,
+            :doc  => nil
+          }
+          val[:type] = locator.extract_text(param.type_expr.offset, param.type_expr.length) unless param.type_expr.nil?
+          # TODO: Need to learn how to read the help/docs for hover support
+          obj.parameters[param.name] = val
+        end
         obj
       end
     end

--- a/lib/puppet-languageserver/puppet_helper.rb
+++ b/lib/puppet-languageserver/puppet_helper.rb
@@ -162,6 +162,11 @@ module PuppetLanguageServer
       @inmemory_cache.object_names_by_section(:class).map(&:to_s)
     end
 
+    # The object cache.  Note this should only be used for testing
+    def self.cache
+      @inmemory_cache
+    end
+
     def self.sidecar_queue
       @sidecar_queue_obj ||= PuppetLanguageServer::SidecarQueue.new
     end

--- a/lib/puppet-languageserver/puppet_helper/cache_objects.rb
+++ b/lib/puppet-languageserver/puppet_helper/cache_objects.rb
@@ -27,6 +27,15 @@ module PuppetLanguageServer
     end
 
     class PuppetClass < BasePuppetObject
+      attr_accessor :doc
+      attr_accessor :parameters
+
+      def from_sidecar!(value)
+        super
+        @doc = value.doc
+        @parameters = value.parameters
+        self
+      end
     end
 
     class PuppetFunction < BasePuppetObject

--- a/lib/puppet-languageserver/sidecar_protocol.rb
+++ b/lib/puppet-languageserver/sidecar_protocol.rb
@@ -115,7 +115,31 @@ module PuppetLanguageServer
       end
 
       class PuppetClass < BasePuppetObject
-        # TODO: Doc, parameters?
+        attr_accessor :parameters
+        attr_accessor :doc
+
+        def to_h
+          super.to_h.merge(
+            'doc'        => doc,
+            'parameters' => parameters
+          )
+        end
+
+        def from_h!(value)
+          super
+
+          self.doc = value['doc']
+          self.parameters = {}
+          unless value['parameters'].nil?
+            value['parameters'].each do |attr_name, obj_attr|
+              parameters[attr_name] = {
+                :type => obj_attr['type'],
+                :doc  => obj_attr['doc']
+              }
+            end
+          end
+          self
+        end
       end
 
       class PuppetClassList < BasePuppetObjectList

--- a/spec/languageserver-sidecar/unit/puppet-languageserver-sidecar/sidecar_protocol_extensions_spec.rb
+++ b/spec/languageserver-sidecar/unit/puppet-languageserver-sidecar/sidecar_protocol_extensions_spec.rb
@@ -29,17 +29,35 @@ describe 'PuppetLanguageServerSidecar::Protocol' do
     let(:puppet_classname) { :rspec_class }
     let(:puppet_class) {
       {
-        'source' => 'source',
-        'line'   => 1,
-        'char'   => 1,
+        'name'       => 'class_name',
+        'type'       => :class,
+        'doc'        => 'doc',
+        'parameters' => { }, # TODO: Need to test this for reals
+        'source'     => 'source',
+        'line'       => 1,
+        'char'       => 1,
       }
     }
 
     it_should_behave_like 'a base Sidecar Protocol extended object'
 
     describe '.from_puppet' do
-      it 'should populate from a Puppet class object' do
-        expect { subject_klass.from_puppet(puppet_classname, puppet_class) }.to_not raise_error
+      it 'should populate from a constructed hash' do
+        result = subject_klass.from_puppet(puppet_classname, puppet_class, nil)
+
+        expect(result.doc).to eq(puppet_class['doc'])
+        expect(result.parameters.count).to eq(puppet_class['parameters'].count)
+      end
+    end
+
+    describe '#from_json' do
+      [:doc, :parameters].each do |testcase|
+        it "should deserialize a serialized #{testcase} value" do
+          serial = subject_klass.from_puppet(puppet_classname, puppet_class, nil)
+          deserial = subject_klass.new.from_json!(serial.to_json)
+
+          expect(deserial.send(testcase)).to eq(serial.send(testcase))
+        end
       end
     end
   end

--- a/spec/languageserver/spec_helper.rb
+++ b/spec/languageserver/spec_helper.rb
@@ -68,6 +68,11 @@ end
 
 def random_sidecar_puppet_class
   result = add_random_basepuppetobject_values!(PuppetLanguageServer::Sidecar::Protocol::PuppetClass.new())
+  result.doc = 'doc' + rand(1000).to_s
+  result.parameters = {
+    "attr_name1" => { :type => "Optional[String]", :doc => 'attr_doc1' },
+    "attr_name2" => { :type => "String", :doc => 'attr_doc2' }
+  }
   result
 end
 

--- a/spec/languageserver/unit/puppet-languageserver/sidecar_protocol_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/sidecar_protocol_spec.rb
@@ -54,7 +54,7 @@ describe 'PuppetLanguageServer::Sidecar::Protocol' do
 
   basepuppetobject_properties = [:key, :calling_source, :source, :line, :char, :length]
   nodegraph_properties = [:dot_content, :error_content]
-  puppetclass_properties = []
+  puppetclass_properties = [:doc, :parameters]
   puppetfunction_properties = [:doc, :arity, :type]
   puppettype_properties = [:doc, :attributes]
   resource_properties = [:manifest]
@@ -138,6 +138,11 @@ describe 'PuppetLanguageServer::Sidecar::Protocol' do
     let(:subject_klass) { PuppetLanguageServer::Sidecar::Protocol::PuppetClass }
     let(:subject) {
       value = subject_klass.new
+      value.doc = 'doc'
+      value.parameters = {
+        "attr_name1" => { :type => "Optional[String]", :doc => 'attr_doc1' },
+        "attr_name2" => { :type => "String", :doc => 'attr_doc2' }
+      }
       add_default_basepuppetobject_values!(value)
     }
 


### PR DESCRIPTION
Previously the Sidecar would only evaluate the name of Puppet Classes and
Defined Types.  This commit adds support for Puppet Class parameters;

Also updates the completion and hover provider for the new information

Fixes #34