### PR TITLE
(GH-80) Release 0.16.0

### DIFF
--- a/lib/puppet-editor-services/version.rb
+++ b/lib/puppet-editor-services/version.rb
@@ -1,5 +1,5 @@
 module PuppetEditorServices
-  PUPPETEDITORSERVICESVERSION = '0.15.1'.freeze unless defined? PUPPETEDITORSERVICESVERSION
+  PUPPETEDITORSERVICESVERSION = '0.16.1'.freeze unless defined? PUPPETEDITORSERVICESVERSION
 
   # @api public
   #


### PR DESCRIPTION
This updates the version file for the 0.16.0 release. This fixes #80 

Note, the rest of https://github.com/lingua-pupuli/puppet-editor-services/blob/master/tools/How_to_release.md needs to be followed