### PR TITLE
(MAINT) Fix release version to 0.16.0

### DIFF
--- a/lib/puppet-editor-services/version.rb
+++ b/lib/puppet-editor-services/version.rb
@@ -1,5 +1,5 @@
 module PuppetEditorServices
-  PUPPETEDITORSERVICESVERSION = '0.16.1'.freeze unless defined? PUPPETEDITORSERVICESVERSION
+  PUPPETEDITORSERVICESVERSION = '0.16.0'.freeze unless defined? PUPPETEDITORSERVICESVERSION
 
   # @api public
   #


### PR DESCRIPTION
This commit corrects the version of the editor
services to `0.16.0` from `0.16.1` which was
merged due to failure of review (me).

The code is otherwise unchanged and should
be released.