### PR TITLE
(GH-80) Update changelog for Keep a Changelog format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,15 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## 0.16.0 - 2018-11-30
 
+### Added
+
 - ([GH-75](https://github.com/lingua-pupuli/puppet-editor-services/issues/75)) Add a node completion item snippet
-- ([GH-34](https://github.com/lingua-pupuli/puppet-editor-services/issues/34)) Autocomplete and hover should retrieve defined types and classes
 - ([GH-68](https://github.com/lingua-pupuli/puppet-editor-services/issues/68)) Language Server should evaluate the locally edited workspace
+
+### Fixed
+
+- ([GH-67](https://github.com/lingua-pupuli/puppet-editor-services/issues/67)) Make resource completion smarter
+- ([GH-34](https://github.com/lingua-pupuli/puppet-editor-services/issues/34)) Autocomplete and hover should retrieve defined types and classes
 
 ## 0.15.1 - 2018-10-30
 


### PR DESCRIPTION
This commit updates the changelog to be in line with Keep a Change log format
and adds a missing issue.