### PR TITLE
(GH-35) Update Language Server command arguments to be like Sidecar

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,49 +36,64 @@ By default the language server will stop if no connection is made within 10 seco
 
 ```
 > bundle exec ruby ./puppet-languageserver --debug=stdout
-I, [2018-04-17T14:21:56.696632 #16656]  INFO -- : Language Server is v0.10.0
-I, [2018-04-17T14:21:56.697136 #16656]  INFO -- : Using Puppet v5.5.0
-I, [2018-04-17T14:21:56.697632 #16656]  INFO -- : Initializing Puppet Helper Cache...
-I, [2018-04-17T14:21:56.697632 #16656]  INFO -- : Initializing settings...
-I, [2018-04-17T14:21:56.699633 #16656]  INFO -- : Starting RPC Server...
-D, [2018-04-17T14:21:56.703638 #16656] DEBUG -- : TCPSRV: Services running. Press ^C to stop
-D, [2018-04-17T14:21:56.703638 #16656] DEBUG -- : TCPSRV: Will stop the server in 10 seconds if no connection is made.
-D, [2018-04-17T14:21:56.704135 #16656] DEBUG -- : TCPSRV: Will stop the server when client disconnects
-LANGUAGE SERVER RUNNING 127.0.0.1:8081
-D, [2018-04-17T14:21:56.707632 #16656] DEBUG -- : TCPSRV: Started listening on 127.0.0.1:8081.
-I, [2018-04-17T14:21:56.717634 #16656]  INFO -- : Using Facter v2.5.1
-I, [2018-04-17T14:21:56.718632 #16656]  INFO -- : Preloading Puppet Types (Sync)...
+I, [2018-12-05T15:19:51.853802 #28756]  INFO -- : Language Server is v0.16.0
+I, [2018-12-05T15:19:51.854809 #28756]  INFO -- : Using Puppet v5.5.8
+D, [2018-12-05T15:19:51.856726 #28756] DEBUG -- : Detected additional puppet settings []
+I, [2018-12-05T15:19:51.867798 #28756]  INFO -- : Initializing Puppet Helper...
+D, [2018-12-05T15:19:51.867798 #28756] DEBUG -- : Initializing Document Store...
+I, [2018-12-05T15:19:51.868726 #28756]  INFO -- : Initializing settings...
+I, [2018-12-05T15:19:51.870728 #28756]  INFO -- : Starting RPC Server...
+D, [2018-12-05T15:19:51.870728 #28756] DEBUG -- : Using Simple TCP
+I, [2018-12-05T15:19:51.871729 #28756]  INFO -- : Using Facter v2.5.1
+I, [2018-12-05T15:19:51.871729 #28756]  INFO -- : Preloading Puppet Types (Async)...
+I, [2018-12-05T15:19:51.872728 #28756]  INFO -- : Preloading Facter (Async)...
+I, [2018-12-05T15:19:51.873727 #28756]  INFO -- : Preloading Functions (Async)...
+I, [2018-12-05T15:19:51.876727 #28756]  INFO -- : Preloading Classes (Async)...
+D, [2018-12-05T15:19:51.876727 #28756] DEBUG -- : SidecarQueue Thread: Running sidecar ["ruby", "C:/Source/puppet-editor-services/puppet-languageserver-sidecar", "--action", "default_types", "--feature-flags="]
+D, [2018-12-05T15:19:51.899795 #28756] DEBUG -- : SidecarQueue Thread: Running sidecar ["ruby", "C:/Source/puppet-editor-services/puppet-languageserver-sidecar", "--action", "default_functions", "--feature-flags="]
+D, [2018-12-05T15:19:51.919794 #28756] DEBUG -- : TCPSRV: Services running. Press ^C to stop
+D, [2018-12-05T15:19:51.920795 #28756] DEBUG -- : TCPSRV: Will stop the server in 10 seconds if no connection is made.
+D, [2018-12-05T15:19:51.921809 #28756] DEBUG -- : TCPSRV: Will stop the server when client disconnects
+LANGUAGE SERVER RUNNING localhost:55087
+D, [2018-12-05T15:19:51.923800 #28756] DEBUG -- : TCPSRV: Started listening on localhost:55087.
+A, [2018-12-05T15:19:54.520501 #28756]   ANY -- : SidecarQueue Thread: Calling sidecar with --action default_functions --feature-flags= returned exitcode 0,
+D, [2018-12-05T15:19:54.532525 #28756] DEBUG -- : SidecarQueue Thread: default_functions returned 270 items
+D, [2018-12-05T15:19:54.533522 #28756] DEBUG -- : SidecarQueue Thread: Running sidecar ["ruby", "C:/Source/puppet-editor-services/puppet-languageserver-sidecar", "--action", "default_classes", "--feature-flags="]
+A, [2018-12-05T15:19:54.576503 #28756]   ANY -- : SidecarQueue Thread: Calling sidecar with --action default_types --feature-flags= returned exitcode 0,
+D, [2018-12-05T15:19:54.638503 #28756] DEBUG -- : SidecarQueue Thread: default_types returned 81 items
+A, [2018-12-05T15:19:56.732112 #28756]   ANY -- : SidecarQueue Thread: Calling sidecar with --action default_classes --feature-flags= returned exitcode 0,
+D, [2018-12-05T15:19:56.732112 #28756] DEBUG -- : SidecarQueue Thread: default_classes returned 0 items
 ...
-D, [2018-04-17T14:22:06.814835 #16656] DEBUG -- : TCPSRV: No connection has been received in 10 seconds.  Shutting down server.
-D, [2018-04-17T14:22:06.815337 #16656] DEBUG -- : TCPSRV: Stopping services
-D, [2018-04-17T14:22:06.816336 #16656] DEBUG -- : TCPSRV: Stopped listening on 127.0.0.1:8081
-D, [2018-04-17T14:22:06.816833 #16656] DEBUG -- : TCPSRV: Started shutdown process. Press ^C to force quit.
-D, [2018-04-17T14:22:06.817333 #16656] DEBUG -- : TCPSRV: Stopping services
-D, [2018-04-17T14:22:06.817333 #16656] DEBUG -- : TCPSRV: Waiting for workers to cycle down
-I, [2018-04-17T14:22:06.876334 #16656]  INFO -- : Language Server exited.
+D, [2018-12-05T15:20:03.319045 #28756] DEBUG -- : TCPSRV: No connection has been received in 10 seconds.  Shutting down server.
+D, [2018-12-05T15:20:03.320049 #28756] DEBUG -- : TCPSRV: Stopping services
+D, [2018-12-05T15:20:03.377052 #28756] DEBUG -- : TCPSRV: Stopped listening on localhost:55087
+D, [2018-12-05T15:20:03.377052 #28756] DEBUG -- : TCPSRV: Started shutdown process. Press ^C to force quit.
+D, [2018-12-05T15:20:03.378052 #28756] DEBUG -- : TCPSRV: Stopping services
+D, [2018-12-05T15:20:03.379050 #28756] DEBUG -- : TCPSRV: Waiting for workers to cycle down
+I, [2018-12-05T15:20:03.632011 #28756]  INFO -- : Language Server exited.
 ```
 
 To make the server run continuously add `--timeout=0` and `--no-stop` to the command line. For example;
 
 ```
 > bundle exec ruby ./puppet-languageserver --debug=stdout --timeout=0 --no-stop
-I, [2018-04-17T14:23:11.286842 #16548]  INFO -- : Language Server is v0.10.0
-I, [2018-04-17T14:23:11.287342 #16548]  INFO -- : Using Puppet v5.5.0
-I, [2018-04-17T14:23:11.288843 #16548]  INFO -- : Initializing Puppet Helper Cache...
-I, [2018-04-17T14:23:11.289343 #16548]  INFO -- : Initializing settings...
-I, [2018-04-17T14:23:11.291841 #16548]  INFO -- : Starting RPC Server...
-D, [2018-04-17T14:23:11.295343 #16548] DEBUG -- : TCPSRV: Services running. Press ^C to stop
-LANGUAGE SERVER RUNNING 127.0.0.1:8081
-D, [2018-04-17T14:23:11.299841 #16548] DEBUG -- : TCPSRV: Started listening on 127.0.0.1:8081.
-I, [2018-04-17T14:23:11.313841 #16548]  INFO -- : Using Facter v2.5.1
-I, [2018-04-17T14:23:11.318343 #16548]  INFO -- : Preloading Puppet Types (Sync)...
-D, [2018-04-17T14:23:11.319842 #16548] DEBUG -- : [PuppetHelper::_load_default_types] Starting
+I, [2018-12-05T15:20:56.302414 #29752]  INFO -- : Language Server is v0.16.0
+I, [2018-12-05T15:20:56.303391 #29752]  INFO -- : Using Puppet v5.5.8
+D, [2018-12-05T15:20:56.306343 #29752] DEBUG -- : Detected additional puppet settings []
+I, [2018-12-05T15:20:56.318333 #29752]  INFO -- : Initializing Puppet Helper...
+D, [2018-12-05T15:20:56.318333 #29752] DEBUG -- : Initializing Document Store...
+I, [2018-12-05T15:20:56.319346 #29752]  INFO -- : Initializing settings...
+I, [2018-12-05T15:20:56.321337 #29752]  INFO -- : Starting RPC Server...
+D, [2018-12-05T15:20:56.321337 #29752] DEBUG -- : Using Simple TCP
+I, [2018-12-05T15:20:56.322332 #29752]  INFO -- : Using Facter v2.5.1
+I, [2018-12-05T15:20:56.323335 #29752]  INFO -- : Preloading Puppet Types (Async)...
+I, [2018-12-05T15:20:56.325337 #29752]  INFO -- : Preloading Facter (Async)...
+I, [2018-12-05T15:20:56.326335 #29752]  INFO -- : Preloading Functions (Async)...
+I, [2018-12-05T15:20:56.327333 #29752]  INFO -- : Preloading Classes (Async)...
 ...
-I, [2018-04-17T14:23:22.869985 #16548]  INFO -- : Preloading Facter (Async)...
-I, [2018-04-17T14:23:22.870489 #16548]  INFO -- : Preloading Functions (Async)...
-I, [2018-04-17T14:23:22.870985 #16548]  INFO -- : Preloading Classes (Async)...
-D, [2018-04-17T14:23:22.875987 #16548] DEBUG -- : [PuppetHelper::_load_default_functions] Starting
-D, [2018-04-17T14:23:22.876985 #16548] DEBUG -- : [PuppetHelper::_load_default_classes] Starting
+D, [2018-12-05T15:20:56.365334 #29752] DEBUG -- : TCPSRV: Services running. Press ^C to stop
+LANGUAGE SERVER RUNNING localhost:55180
+D, [2018-12-05T15:20:56.374333 #29752] DEBUG -- : TCPSRV: Started listening on localhost:55180.
 ...
 ```
 
@@ -99,10 +114,18 @@ D, [2018-04-17T14:23:22.876985 #16548] DEBUG -- : [PuppetHelper::_load_default_c
 
 ```
 > ruby puppet-languageserver
-LANGUAGE SERVER RUNNING 127.0.0.1:8081
+LANGUAGE SERVER RUNNING 127.0.0.1:55086
 ```
 
-Note the language server will stop after 10 seconds if no client connection is made.
+> Note the language server will stop after 10 seconds if no client connection is made.
+
+Note that the Language Server will use TCP as the default transport on `localhost` at a random port.  The IP Address and Port can be changed using the `--ip` and `--port` arguments respectively.  For example to listen on all interfaces on port 9000;
+
+```
+> ruby ./puppet-languageserver --ip=0.0.0.0 --port=9000
+```
+
+To change the protocol to STDIO, that is using STDOUT and STDIN, use the `--stdio` argument.
 
 ## Command line arguments
 
@@ -116,11 +139,79 @@ Usage: puppet-languageserver.rb [options]
         --debug=DEBUG                Output debug information.  Either specify a filename or 'STDOUT'.  Default is no debug output
     -s, --slow-start                 Delay starting the Language Server until Puppet initialisation has completed.  Default is to start fast
         --stdio                      Runs the server in stdio mode, without a TCP listener
-        --enable-file-cache          Enables the file system cache for Puppet Objects (types, class etc.)
+        --enable-file-cache          ** DEPRECATED ** Enables the file system cache for Puppet Objects (types, class etc.)
+        --[no-]cache                 Enable or disable all caching inside the sidecar. By default caching is enabled.
+        --feature-flags=FLAGS        A list of comma delimited feature flags
+        --puppet-settings=TEXT       Comma delimited list of settings to pass into Puppet e.g. --vardir,/opt/test-fixture
         --local-workspace=PATH       The workspace or file path that will be used to provide module-specific functionality. Default is no workspace path.
     -h, --help                       Prints this help
     -v, --version                    Prints the Langauge Server version
 ```
+
+# Language Server Sidecar
+
+## How to run the Language Server for Development
+
+The Language Server Sidecar is a process used by the Language Server to get information about Puppet's environment, for example, all available functions, classes, and custom types. This tool is typically only run by the Language Server itself, but it can be used to diagnose issues.
+
+The sidecar is told to perform an action (using the `action`) parameter and then, by default, outputs the JSON encoded result to STDOUT.  This can be changed to a text file using the `--output=PATH` argument.
+
+Note that using the `--debug=STDOUT` option without directing the output to a text file will generate output on STDOUT which cannot be deserialized correctly. Typically this only used by a developer to inspect what the Sidecar is doing.
+
+### Example usage
+
+#### Confirm that the Sidecar loads correctly
+
+The `noop` action just outputs an empty JSON array but can be used to confirm that the Sidecar does not error while loading Puppet.
+
+```
+> bundle exec ruby ./puppet-languageserver-sidecar --action=noop
+[]
+```
+
+#### Output all default Puppet Types
+
+```
+> bundle exec ruby ./puppet-languageserver-sidecar --action=default_types
+[{"key":"anchor","calling_source":"puppet/cache/lib/puppet/type/anchor.rb","sou ...
+```
+
+#### Output all default Puppet Functions with a different puppet configuration, and debug information
+
+```
+> bundle exec ruby ./puppet-languageserver-sidecar --action=default_types --puppet-settings=--vardir,./test/vardir,--confdir,./test/confdir --debug=STDOUT
+I, [2018-12-05T15:42:56.679837 #51864]  INFO -- : Language Server Sidecar is v0.16.0
+I, [2018-12-05T15:42:56.679837 #51864]  INFO -- : Using Puppet v5.5.8
+D, [2018-12-05T15:42:56.680820 #51864] DEBUG -- : Detected additional puppet settings ["--vardir", "./test/vardir", "--confdir", "./test/confdir"]
+D, [2018-12-05T15:42:56.690876 #51864] DEBUG -- : [PuppetHelper::load_functions] Starting
+D, [2018-12-05T15:42:56.752804 #51864] DEBUG -- : [PuppetLanguageServerSidecar::load] Loading lib/puppet/parser/functions/assert_type.rb from cache
+...
+[{"key":"debug","calling_source":"lib/puppet/parser/functions.rb", ...
+```
+
+#### Output all Puppet Classes in a workspace directory
+
+```
+> bundle exec ruby ./puppet-languageserver-sidecar --action=workspace_classes --local-workspace=C:\source\puppetlabs-sqlserver
+[{"key":"sqlserver::config","calling_source":"C:/Source/puppetlabs-sqlserver/manifests/config.pp","source":"C:/Source/puppetlabs-sqlserver/manifests/config.pp","line":25,"ch...
+```
+
+## Command line arguments
+
+```
+Usage: puppet-languageserver-sidecar.rb [options]
+    -a, --action=NAME                The action for the sidecar to take. Expected ["noop", "default_classes", "default_functions", "default_types", "node_graph", "resource_list", "workspace_classes", "workspace_functions", "workspace_types"]
+    -c, --action-parameters=JSON     JSON Encoded string containing the parameters for the sidecar action
+    -w, --local-workspace=PATH       The workspace or file path that will be used to provide module-specific functionality. Default is no workspace path
+    -o, --output=PATH                The file to save the output from the sidecar. Default is output to STDOUT
+    -p, --puppet-settings=TEXT       Comma delimited list of settings to pass into Puppet e.g. --vardir,/opt/test-fixture
+    -f, --feature-flags=FLAGS        A list of comma delimited feature flags to pass the the sidecar
+    -n, --[no-]cache                 Enable or disable all caching inside the sidecar. By default caching is enabled.
+        --debug=DEBUG                Output debug information.  Either specify a filename or 'STDOUT'. Default is no debug output
+    -h, --help                       Prints this help
+    -v, --version                    Prints the Langauge Server version
+```
+
 
 # Debug Server
 

--- a/lib/puppet-languageserver/puppet_helper.rb
+++ b/lib/puppet-languageserver/puppet_helper.rb
@@ -18,9 +18,11 @@ module PuppetLanguageServer
     @default_classes_loaded = nil
     @inmemory_cache = nil
     @sidecar_queue_obj = nil
+    @helper_options = nil
 
-    def self.configure_cache(options = {})
-      @inmemory_cache = PuppetLanguageServer::PuppetHelper::Cache.new(options)
+    def self.initialize_helper(options = {})
+      @helper_options = options
+      @inmemory_cache = PuppetLanguageServer::PuppetHelper::Cache.new
       sidecar_queue.cache = @inmemory_cache
     end
 
@@ -197,7 +199,7 @@ module PuppetLanguageServer
     end
 
     def self.sidecar_queue
-      @sidecar_queue_obj ||= PuppetLanguageServer::SidecarQueue.new
+      @sidecar_queue_obj ||= PuppetLanguageServer::SidecarQueue.new(@helper_options)
     end
     private_class_method :sidecar_queue
 

--- a/lib/puppet_languageserver_sidecar.rb
+++ b/lib/puppet_languageserver_sidecar.rb
@@ -93,7 +93,7 @@ module PuppetLanguageServerSidecar
           args[:output] = path
         end
 
-        opts.on('-p', '--puppet-settings=TEXT', Array, 'Comma dilimited list of settings to pass into Puppet e.g. --vardir,/opt/test-fixture') do |text|
+        opts.on('-p', '--puppet-settings=TEXT', Array, 'Comma delimited list of settings to pass into Puppet e.g. --vardir,/opt/test-fixture') do |text|
           args[:puppet_settings] = text
         end
 

--- a/spec/languageserver/spec_helper.rb
+++ b/spec/languageserver/spec_helper.rb
@@ -24,7 +24,7 @@ def wait_for_puppet_loading
              PuppetLanguageServer::PuppetHelper.default_classes_loaded?
     sleep(1)
     interation += 1
-    next if interation < 30
+    next if interation < 60
     raise <<-ERRORMSG
             Puppet has not be initialised in time:
             functions_loaded? = #{PuppetLanguageServer::PuppetHelper.default_functions_loaded?}


### PR DESCRIPTION
Previously some command line arguments used by the Sidecar were not present in
the Language Server, therefore they could never be used.  This commit;

* Adds the --[no-]cache, --feature-flags and --puppet-settings=TEXT settings
  and modifies the Puppet Helper and Sidecar Queue to then pass these settings
  along to the sidecar
* Fixes a simple typo in the Sidecar settings
* Deprecates the --enable-file-cache setting as it no longer has any effect
* Adds some logging on Language Server startup to output the puppet settings and
  initializes them as early as possible

---

Fixes #35 on the Editor Services side.  An additional PR will need to be raised for the VSCode extension to pass in the `--modulepath` settings