### PR TITLE
(GH-90) Prepare for 0.17.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Unreleased
 
+## 0.17.0 - 2018-12-14
+
+### Added
+
+- ([GH-20](https://github.com/lingua-pupuli/puppet-editor-services/issues/20)) Add support for Control Repositories for intellisense e.g. hover, completion
+- ([GH-88](https://github.com/lingua-pupuli/puppet-editor-services/issues/20)) Add a workspace symbol provider
+
+### Changed
+
+- ([GH-35](https://github.com/lingua-pupuli/puppet-editor-services/issues/35)) Update Language Server command arguments to be like Sidecar
+
 ## 0.16.0 - 2018-11-30
 
 ### Added

--- a/lib/puppet-editor-services/version.rb
+++ b/lib/puppet-editor-services/version.rb
@@ -1,5 +1,5 @@
 module PuppetEditorServices
-  PUPPETEDITORSERVICESVERSION = '0.16.0'.freeze unless defined? PUPPETEDITORSERVICESVERSION
+  PUPPETEDITORSERVICESVERSION = '0.17.0'.freeze unless defined? PUPPETEDITORSERVICESVERSION
 
   # @api public
   #


### PR DESCRIPTION
Fixes #90 

This commit prepares the project for a 0.17.0 release.