### PR TITLE
(maint) Fix validation of puppetfiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
     - PUPPET_GEM_VERSION="~> 4.0"
       RUBY_VER=2.1.9
       RAKE_TASK="test_languageserver test_languageserver_sidecar test_debugserver"
+      BUNDLER_VERSION=1.17.3
     # Latest 5.x Puppet
     - PUPPET_GEM_VERSION="~> 5.0"
       RUBY_VER=2.4.1
@@ -45,6 +46,9 @@ install:
       rvm use $RUBY_VER;
       ruby -v;
       gem -v;
+      if [ "$BUNDLER_VERSION" != "" ]; then
+        gem install -v $BUNDLER_VERSION bundler --no-rdoc --no-ri;
+      fi;
       bundle -v;
       bundle install;
       cat Gemfile.lock;

--- a/lib/puppet-languageserver/puppetfile/validation_provider.rb
+++ b/lib/puppet-languageserver/puppetfile/validation_provider.rb
@@ -6,7 +6,7 @@ module PuppetLanguageServer
         1000
       end
 
-      def self.validate(content, _workspace, _max_problems = 100)
+      def self.validate(content, _max_problems = 100)
         result = []
         # TODO: Need to implement max_problems
         _problems = 0


### PR DESCRIPTION
Previously validating puppetfiles was silently failing due to;

"Error in ValidationQueue Thread: wrong number of arguments (given 1, expected 2..3)"

This commit changes the puppetfile validation method signature to mirror that of the
manifest validation provider.