### PR TITLE
(GH-24) Allow parsing in tasks mode

### DIFF
--- a/lib/puppet-languageserver-sidecar/puppet_monkey_patches.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_monkey_patches.rb
@@ -16,7 +16,7 @@ module Puppet
           # Append the caller information
           result[:source_location] = {
             :source => caller.absolute_path,
-            :line   => caller.lineno - 1, # Convert to a zero based line number system
+            :line   => caller.lineno - 1 # Convert to a zero based line number system
           }
           monkey_append_function_info(name, result)
 
@@ -69,7 +69,7 @@ module Puppet
         if block_given? && !block.source_location.nil?
           result._source_location = {
             :source => block.source_location[0],
-            :line   => block.source_location[1] - 1, # Convert to a zero based line number system
+            :line   => block.source_location[1] - 1 # Convert to a zero based line number system
           }
         end
         result

--- a/lib/puppet-languageserver/document_store.rb
+++ b/lib/puppet-languageserver/document_store.rb
@@ -52,6 +52,15 @@ module PuppetLanguageServer
       end
     end
 
+    # Plan files https://puppet.com/docs/bolt/1.x/writing_plans.html#concept-4485
+    # exist in modules (requires metadata.json) and are in the `/plans` directory
+    def self.module_plan_file?(uri)
+      return false unless store_has_module_metadata?
+      relative_path = PuppetLanguageServer::UriHelper.relative_uri_path(PuppetLanguageServer::UriHelper.build_file_uri(store_root_path), uri, !windows?)
+      return false if relative_path.nil?
+      relative_path.start_with?('/plans/')
+    end
+
     # Workspace management
     WORKSPACE_CACHE_TTL_SECONDS = 60
     def self.initialize_store(options = {})
@@ -150,5 +159,12 @@ module PuppetLanguageServer
       Dir.exist?(path)
     end
     private_class_method :dir_exist?
+
+    def self.windows?
+      # Ruby only sets File::ALT_SEPARATOR on Windows and the Ruby standard
+      # library uses that to test what platform it's on.
+      !!File::ALT_SEPARATOR # rubocop:disable Style/DoubleNegation
+    end
+    private_class_method :windows?
   end
 end

--- a/lib/puppet-languageserver/manifest/completion_provider.rb
+++ b/lib/puppet-languageserver/manifest/completion_provider.rb
@@ -1,17 +1,23 @@
 module PuppetLanguageServer
   module Manifest
     module CompletionProvider
-      def self.complete(content, line_num, char_num)
+      def self.complete(content, line_num, char_num, options = {})
+        options = {
+          :tasks_mode => false
+        }.merge(options)
         items = []
         incomplete = false
 
-        result = PuppetLanguageServer::PuppetParserHelper.object_under_cursor(content, line_num, char_num, true, [Puppet::Pops::Model::QualifiedName, Puppet::Pops::Model::BlockExpression])
-
+        result = PuppetLanguageServer::PuppetParserHelper.object_under_cursor(content, line_num, char_num,
+                                                                              :multiple_attempts  => true,
+                                                                              :disallowed_classes => [Puppet::Pops::Model::QualifiedName, Puppet::Pops::Model::BlockExpression],
+                                                                              :tasks_mode         => options[:tasks_mode])
         if result.nil?
           # We are in the root of the document.
 
           # Add keywords
           keywords(%w[class define node application site]) { |x| items << x }
+          keywords(%w[plan]) { |x| items << x } if options[:tasks_mode]
 
           # Add resources
           all_resources { |x| items << x }

--- a/lib/puppet-languageserver/manifest/definition_provider.rb
+++ b/lib/puppet-languageserver/manifest/definition_provider.rb
@@ -1,9 +1,13 @@
 module PuppetLanguageServer
   module Manifest
     module DefinitionProvider
-      def self.find_definition(content, line_num, char_num)
-        result = PuppetLanguageServer::PuppetParserHelper.object_under_cursor(content, line_num, char_num, false, [Puppet::Pops::Model::BlockExpression])
-
+      def self.find_definition(content, line_num, char_num, options = {})
+        options = {
+          :tasks_mode => false
+        }.merge(options)
+        result = PuppetLanguageServer::PuppetParserHelper.object_under_cursor(content, line_num, char_num,
+                                                                              :disallowed_classes => [Puppet::Pops::Model::BlockExpression],
+                                                                              :tasks_mode         => options[:tasks_mode])
         return nil if result.nil?
 
         path = result[:path]

--- a/lib/puppet-languageserver/manifest/hover_provider.rb
+++ b/lib/puppet-languageserver/manifest/hover_provider.rb
@@ -1,8 +1,13 @@
 module PuppetLanguageServer
   module Manifest
     module HoverProvider
-      def self.resolve(content, line_num, char_num)
-        result = PuppetLanguageServer::PuppetParserHelper.object_under_cursor(content, line_num, char_num, false, [Puppet::Pops::Model::QualifiedName, Puppet::Pops::Model::BlockExpression])
+      def self.resolve(content, line_num, char_num, options = {})
+        options = {
+          :tasks_mode => false
+        }.merge(options)
+        result = PuppetLanguageServer::PuppetParserHelper.object_under_cursor(content, line_num, char_num,
+                                                                              :disallowed_classes => [Puppet::Pops::Model::QualifiedName, Puppet::Pops::Model::BlockExpression],
+                                                                              :tasks_mode         => options[:tasks_mode])
         return LanguageServer::Hover.create_nil_response if result.nil?
 
         path = result[:path]

--- a/lib/puppet-languageserver/message_router.rb
+++ b/lib/puppet-languageserver/message_router.rb
@@ -97,7 +97,7 @@ module PuppetLanguageServer
         begin
           case documents.document_type(file_uri)
           when :manifest
-            request.reply_result(PuppetLanguageServer::Manifest::CompletionProvider.complete(content, line_num, char_num))
+            request.reply_result(PuppetLanguageServer::Manifest::CompletionProvider.complete(content, line_num, char_num, :tasks_mode => PuppetLanguageServer::DocumentStore.module_plan_file?(file_uri)))
           else
             raise "Unable to provide completion on #{file_uri}"
           end
@@ -123,7 +123,7 @@ module PuppetLanguageServer
         begin
           case documents.document_type(file_uri)
           when :manifest
-            request.reply_result(PuppetLanguageServer::Manifest::HoverProvider.resolve(content, line_num, char_num))
+            request.reply_result(PuppetLanguageServer::Manifest::HoverProvider.resolve(content, line_num, char_num, :tasks_mode => PuppetLanguageServer::DocumentStore.module_plan_file?(file_uri)))
           else
             raise "Unable to provide hover on #{file_uri}"
           end
@@ -140,7 +140,7 @@ module PuppetLanguageServer
         begin
           case documents.document_type(file_uri)
           when :manifest
-            request.reply_result(PuppetLanguageServer::Manifest::DefinitionProvider.find_definition(content, line_num, char_num))
+            request.reply_result(PuppetLanguageServer::Manifest::DefinitionProvider.find_definition(content, line_num, char_num, :tasks_mode => PuppetLanguageServer::DocumentStore.module_plan_file?(file_uri)))
           else
             raise "Unable to provide definition on #{file_uri}"
           end
@@ -155,8 +155,7 @@ module PuppetLanguageServer
         begin
           case documents.document_type(file_uri)
           when :manifest
-            result = PuppetLanguageServer::Manifest::DocumentSymbolProvider.extract_document_symbols(content)
-            request.reply_result(result)
+            request.reply_result(PuppetLanguageServer::Manifest::DocumentSymbolProvider.extract_document_symbols(content, :tasks_mode => PuppetLanguageServer::DocumentStore.module_plan_file?(file_uri)))
           else
             raise "Unable to provide definition on #{file_uri}"
           end

--- a/lib/puppet-languageserver/puppet_monkey_patches.rb
+++ b/lib/puppet-languageserver/puppet_monkey_patches.rb
@@ -1,3 +1,35 @@
+# Monkey Patch the Puppet language parser so we can globally lock any changes to the
+# global setting Puppet[:tasks].  We need to manage this so we can switch between
+# parsing modes.  Unfortunately we can't do this as method parameter, only via the
+# global Puppet settings which is not thread safe
+$PuppetParserMutex = Mutex.new # rubocop:disable Style/GlobalVars
+module Puppet
+  module Pops
+    module Parser
+      class Parser
+        def singleton_parse_string(code, task_mode = false, path = nil)
+          $PuppetParserMutex.synchronize do # rubocop:disable Style/GlobalVars
+            begin
+              original_taskmode = Puppet[:tasks] if Puppet.tasks_supported?
+              Puppet[:tasks] = task_mode if Puppet.tasks_supported?
+              return parse_string(code, path)
+            ensure
+              Puppet[:tasks] = original_taskmode if Puppet.tasks_supported?
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+module Puppet
+  # Tasks first appeared in Puppet 5.4.0
+  def self.tasks_supported?
+    Gem::Version.new(Puppet.version) >= Gem::Version.new('5.4.0')
+  end
+end
+
 # MUST BE LAST!!!!!!
 # Suppress any warning messages to STDOUT.  It can pollute stdout when running in STDIO mode
 Puppet::Util::Log.newdesttype :null_logger do

--- a/lib/puppet-languageserver/puppet_parser_helper.rb
+++ b/lib/puppet-languageserver/puppet_parser_helper.rb
@@ -72,9 +72,11 @@ module PuppetLanguageServer
         when :noop
           new_content = content
         when :remove_char
+          next if line_num.zero? && char_num.zero?
           new_content = remove_char_at(content, line_offsets, line_num, char_num)
           move_offset = -1
         when :remove_word
+          next if line_num.zero? && char_num.zero?
           next_char = get_char_at(content, line_offsets, line_num, char_num)
 
           while /[[:word:]]/ =~ next_char

--- a/lib/puppet-languageserver/uri_helper.rb
+++ b/lib/puppet-languageserver/uri_helper.rb
@@ -1,7 +1,35 @@
+require 'uri'
+require 'puppet'
+
 module PuppetLanguageServer
   module UriHelper
     def self.build_file_uri(path)
-      path.start_with?('/') ? 'file://' + path : 'file:///' + path
+      'file://' + Puppet::Util.uri_encode(path.start_with?('/') ? path : '/' + path)
+    end
+
+    # Compares two URIs and returns the relative path
+    #
+    # @param root_uri [String] The root URI to compare to
+    # @param uri [String] The URI to compare to the root
+    # @param case_sensitive [Boolean] Whether the path comparison is case senstive or not.  Default is true
+    # @return [String] Returns the relative path string if the URI is indeed a child of the root, otherwise returns nil
+    def self.relative_uri_path(root_uri, uri, case_sensitive = true)
+      actual_root = URI(root_uri)
+      actual_uri = URI(uri)
+      return nil unless actual_root.scheme == actual_uri.scheme
+
+      # CGI.unescape doesn't handle space rules properly in uri paths
+      # URI.unescape does, but returns strings in their original encoding
+      # Mostly safe here as we're only worried about file based URIs
+      root_path = URI.unescape(actual_root.path) # rubocop:disable Lint/UriEscapeUnescape
+      uri_path = URI.unescape(actual_uri.path) # rubocop:disable Lint/UriEscapeUnescape
+      if case_sensitive
+        return nil unless uri_path.slice(0, root_path.length) == root_path
+      else
+        return nil unless uri_path.slice(0, root_path.length).casecmp(root_path).zero?
+      end
+
+      uri_path.slice(root_path.length..-1)
     end
   end
 end

--- a/lib/puppet-languageserver/validation_queue.rb
+++ b/lib/puppet-languageserver/validation_queue.rb
@@ -50,7 +50,7 @@ module PuppetLanguageServer
       document_type = PuppetLanguageServer::DocumentStore.document_type(file_uri)
       content = documents.document(file_uri, doc_version)
       return nil if content.nil?
-      result = validate(document_type, content)
+      result = validate(file_uri, document_type, content)
 
       # Send the response
       connection_object.reply_diagnostics(file_uri, result)
@@ -78,11 +78,11 @@ module PuppetLanguageServer
     end
 
     # Validate a document
-    def self.validate(document_type, content)
+    def self.validate(document_uri, document_type, content)
       # Perform validation
       case document_type
       when :manifest
-        PuppetLanguageServer::Manifest::ValidationProvider.validate(content)
+        PuppetLanguageServer::Manifest::ValidationProvider.validate(content, :tasks_mode => PuppetLanguageServer::DocumentStore.module_plan_file?(document_uri))
       when :epp
         PuppetLanguageServer::Epp::ValidationProvider.validate(content)
       when :puppetfile
@@ -117,7 +117,7 @@ module PuppetLanguageServer
         end
 
         # Perform validation
-        result = validate(document_type, content)
+        result = validate(file_uri, document_type, content)
 
         # Check if the document is still latest version
         current_version = documents.document_version(file_uri)

--- a/spec/languageserver/integration/puppet-languageserver/document_store_spec.rb
+++ b/spec/languageserver/integration/puppet-languageserver/document_store_spec.rb
@@ -161,6 +161,36 @@ describe 'PuppetLanguageServer::DocumentStore' do
     it_should_behave_like 'a metadata.json workspace', expected_root
     it_should_behave_like 'a cached workspace'
     it_should_behave_like 'a terminating file finder', 3, 1
+
+    ['/plans/test.pp', '/plans/a/b/c/something.pp'].each do |testcase|
+      it "should detect '#{testcase}' as a plan file" do
+        file_uri = PuppetLanguageServer::UriHelper.build_file_uri(subject.store_root_path) + testcase
+        expect(subject.module_plan_file?(file_uri)).to be(true)
+      end
+    end
+
+    ['/plan__s/test.pp', 'plans/something.txt', '/plantest.pp', ].each do |testcase|
+      it "should not detect '#{testcase}' as a plan file" do
+        file_uri = PuppetLanguageServer::UriHelper.build_file_uri(subject.store_root_path) + testcase
+        expect(subject.module_plan_file?(file_uri)).to be(false)
+      end
+    end
+
+    it 'should detect plan files as case insensitive on Windows' do
+      allow(subject).to receive(:windows?).and_return(true)
+      file_uri = PuppetLanguageServer::UriHelper.build_file_uri(subject.store_root_path) + '/plans/test.pp'
+      expect(subject.module_plan_file?(file_uri)).to be(true)
+      file_uri = PuppetLanguageServer::UriHelper.build_file_uri(subject.store_root_path.upcase) + '/plans/test.pp'
+      expect(subject.module_plan_file?(file_uri)).to be(true)
+    end
+
+    it 'should detect plan files as case sensitive not on Windows' do
+      allow(subject).to receive(:windows?).and_return(false)
+      file_uri = PuppetLanguageServer::UriHelper.build_file_uri(subject.store_root_path) + '/plans/test.pp'
+      expect(subject.module_plan_file?(file_uri)).to be(true)
+      file_uri = PuppetLanguageServer::UriHelper.build_file_uri(subject.store_root_path).upcase + '/plans/test.pp'
+      expect(subject.module_plan_file?(file_uri.upcase)).to be(false)
+    end
   end
 
   context 'given a workspace option which has a parent directory with metadata.json' do

--- a/spec/languageserver/integration/puppet-languageserver/manifest/completion_provider_spec.rb
+++ b/spec/languageserver/integration/puppet-languageserver/manifest/completion_provider_spec.rb
@@ -73,6 +73,18 @@ describe 'completion_provider' do
       end
     end
 
+    context 'Given a Puppet Plan', :if => Puppet.tasks_supported? do
+      let(:content) { <<-EOT
+        plan mymodule::my_plan(
+        ) {
+        }
+        EOT
+      }
+      it "should not raise an error" do
+        result = subject.complete(content, 0, 1, { :tasks_mode => true})
+      end
+    end
+
     context "Given a simple valid manifest" do
       let(:content) { <<-EOT
 class Alice {

--- a/spec/languageserver/integration/puppet-languageserver/manifest/definition_provider_spec.rb
+++ b/spec/languageserver/integration/puppet-languageserver/manifest/definition_provider_spec.rb
@@ -51,6 +51,18 @@ describe 'definition_provider' do
       wait_for_puppet_loading
     end
 
+    context 'Given a Puppet Plan', :if => Puppet.tasks_supported? do
+      let(:content) { <<-EOT
+        plan mymodule::my_plan(
+        ) {
+        }
+        EOT
+      }
+      it "should not raise an error" do
+        result = subject.find_definition(content, 0, 1, { :tasks_mode => true})
+      end
+    end
+
     context 'When cursor is on a function name' do
       let(:content) { <<-EOT
 class Test::NoParams {

--- a/spec/languageserver/integration/puppet-languageserver/manifest/hover_provider_spec.rb
+++ b/spec/languageserver/integration/puppet-languageserver/manifest/hover_provider_spec.rb
@@ -58,6 +58,18 @@ EOT
       end
     end
 
+    context 'Given a Puppet Plan', :if => Puppet.tasks_supported? do
+      let(:content) { <<-EOT
+        plan mymodule::my_plan(
+        ) {
+        }
+        EOT
+      }
+      it "should not raise an error" do
+        result = subject.resolve(content, 0, 1, { :tasks_mode => true})
+      end
+    end
+
     describe 'when cursor is in the root of the document' do
       let(:line_num) { 5 }
       let(:char_num) { 3 }

--- a/spec/languageserver/integration/puppet-languageserver/manifest/validation_provider_spec.rb
+++ b/spec/languageserver/integration/puppet-languageserver/manifest/validation_provider_spec.rb
@@ -109,6 +109,18 @@ describe 'PuppetLanguageServer::Manifest::ValidationProvider' do
       end
     end
 
+    context 'Given a Puppet Plan', :if => Puppet.tasks_supported? do
+      let(:manifest) { <<-EOT
+        plan mymodule::my_plan(
+        ) {
+        }
+        EOT
+      }
+      it "should not raise an error" do
+        result = subject.validate(manifest, { :tasks_mode => true})
+      end
+    end
+
     describe "Given a complete manifest with no validation errors" do
       let(:manifest) { "user { 'Bob': ensure => 'present' }" }
 

--- a/spec/languageserver/unit/puppet-languageserver/manifest/document_symbol_provider_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/manifest/document_symbol_provider_spec.rb
@@ -43,6 +43,18 @@ describe 'PuppetLanguageServer::Manifest::DocumentSymbolProvider' do
 
   context 'with Puppet 5.0 and above', :if => Gem::Version.new(Puppet.version) >= Gem::Version.new('5.0.0') do
     describe '#extract_document_symbols' do
+      context 'Given a Puppet Plan', :if => Puppet.tasks_supported? do
+        let(:content) { <<-EOT
+          plan mymodule::my_plan(
+          ) {
+          }
+          EOT
+        }
+        it "should not raise an error" do
+          result = subject.extract_document_symbols(content, { :tasks_mode => true})
+        end
+      end
+
       it 'should find a class in the document root' do
         content = "class foo {\n}"
         result = subject.extract_document_symbols(content)

--- a/spec/languageserver/unit/puppet-languageserver/uri_helper_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/uri_helper_spec.rb
@@ -1,14 +1,46 @@
 require 'spec_helper'
 
 describe 'uri_helper' do
+  let(:subject) { PuppetLanguageServer::UriHelper }
+
   describe '#build_file_uri' do
     it 'should return /// without leading slash' do
-      test = PuppetLanguageServer::UriHelper.build_file_uri('C:\foo.pp')
-      expect(test).to eq('file:///C:\foo.pp')
+      test = subject.build_file_uri('C:\foo.pp')
+      expect(test).to match('^file:///C')
+    end
+    it 'should return the uri escaped' do
+      test = subject.build_file_uri('C:\foo.pp')
+      expect(test).to eq('file:///C:%5Cfoo.pp')
     end
     it 'should return // with a leading slash' do
-      test = PuppetLanguageServer::UriHelper.build_file_uri('/opt/foo/foo.pp')
+      test = subject.build_file_uri('/opt/foo/foo.pp')
       expect(test).to eq('file:///opt/foo/foo.pp')
+    end
+  end
+
+  describe '#relative_uri_path' do
+    it 'should return nil when the uri schemes differ' do
+      expect(subject.relative_uri_path('file:///somewhere', 'http:///somewhere')).to be_nil
+    end
+
+    it 'should return nil if the uri is not a child of the root' do
+      expect(subject.relative_uri_path('file:///somewhere', 'file:///foo/bar')).to be_nil
+    end
+
+    it 'should return nil if the uri is not a child of the root, when case sensitive' do
+      expect(subject.relative_uri_path('file:///Foo/', 'file:///foo/bar')).to be_nil
+    end
+
+    it 'should unescape URIs when comparing' do
+      expect(subject.relative_uri_path('file:///%66%6F%6F/', 'file:///foo/b%61r')).to eq('bar')
+    end
+
+    it 'should return the relative path if the uri is a child of the root' do
+      expect(subject.relative_uri_path('file:///foo/', 'file:///foo/bar')).to eq('bar')
+    end
+
+    it 'should return the relative path if the uri is a child of the root and not case-sensitive' do
+      expect(subject.relative_uri_path('file:///Foo/', 'file:///foo/bar', false)).to eq('bar')
     end
   end
 end

--- a/spec/languageserver/unit/puppet-languageserver/validation_queue_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/validation_queue_spec.rb
@@ -72,7 +72,7 @@ describe 'validation_queue' do
         ])
 
         # We only expect the following results to be returned
-        expect(PuppetLanguageServer::Manifest::ValidationProvider).to receive(:validate).with(file_content2).and_return(validation_result)
+        expect(PuppetLanguageServer::Manifest::ValidationProvider).to receive(:validate).with(file_content2, Hash).and_return(validation_result)
         expect(PuppetLanguageServer::Epp::ValidationProvider).to receive(:validate).with(file_content1).and_return(validation_result)
         expect(PuppetLanguageServer::Puppetfile::ValidationProvider).to receive(:validate).with(file_content1).and_return(validation_result)
         expect(connection).to receive(:reply_diagnostics).with(MANIFEST_FILENAME, validation_result)
@@ -93,7 +93,7 @@ describe 'validation_queue' do
         validation_result = [{ 'result' => 'MockResult' }]
 
         before(:each) do
-          expect(PuppetLanguageServer::Manifest::ValidationProvider).to receive(:validate).with(FILE_CONTENT).and_return(validation_result)
+          expect(PuppetLanguageServer::Manifest::ValidationProvider).to receive(:validate).with(FILE_CONTENT, Hash).and_return(validation_result)
         end
 
         it_should_behave_like "single document which sends validation results", MANIFEST_FILENAME, FILE_CONTENT, validation_result
@@ -155,7 +155,7 @@ describe 'validation_queue' do
       validation_result = [{ 'result' => 'MockResult' }]
 
       before(:each) do
-        expect(PuppetLanguageServer::Manifest::ValidationProvider).to receive(:validate).with(FILE_CONTENT).and_return(validation_result)
+        expect(PuppetLanguageServer::Manifest::ValidationProvider).to receive(:validate).with(FILE_CONTENT, Hash).and_return(validation_result)
       end
 
       it_should_behave_like "document which sends validation results", MANIFEST_FILENAME, FILE_CONTENT, validation_result


### PR DESCRIPTION
The Puppet language introduced Puppet Tasks and Plans as part of
Puppet 5.4.0 [1].  A special parsing switch `--tasks` was
introduced which changes the behaviour of the Puppet parser, that
is switching it into "tasks" mode.  Unfortunately this switch is
global to all Puppet parsing therefore to dynamically switch it
like we do in Editor Services, this required a global mutex to be
used.

Note that this commit does not add Puppet Tasks/Plans intellisense
but merely allows the standard manifest providers (completion,
validation etc.) to actually function instead of silently failing

This commit;
* Modifies the Puppet parser, via monkey patching, to implement a
  "singleton" parsing method that dynamically, and safely, switch
  the parsing mode on a per request basis
* Modifies the Document Store to detect whether a File URI is a
  Puppet Task/Plan based on the relative path of the file versus
  the module root.
* Modifies the various providers to call the parsing helper in the
  correct mode
* Modifies the Message Router to detect whether a file is a Puppet
  Task/Plan and then sets the appropriate mode when calling the
  manifest providers (completion, validation etc.)

[1] https://puppet.com/docs/bolt/1.x/writing_plans.html#concept-4485

Fixes #24

---

- [x] Extend parsing to dynamically switch `Puppet[:tasks]`
- [x] Add tests for parsing plan files

### Completion Provider
- [x] Extend manifest completion provider to understand plan files
- [x] Add tests for completing plan files

### Definition Provider
- [x] Extend manifest definition provider to understand plan files
- [x] Add tests for defining plan files

### Document Symbol Provider
- [x] Extend manifest doc. symbol provider to understand plan files
- [x] Add tests for symbol-extracting plan files

### Hover Provider
- [x] Extend manifest hover provider to understand plan files
- [x] Add tests for hovering in plan files

### Validation Provider
- [x] modify Validation parsing to dynamically switch `Puppet[:tasks]`
- [x] Extend validation provider to understand plan files
- [x] Add tests for validating plan files