### PR TITLE
{WIP} Use the Puppet 4 API (Puppet PAL)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ group :development do
     gem 'puppet', ENV['PUPPET_GEM_VERSION'], :require => false
   else
     gem 'puppet',                            :require => false
+    #gem "puppet", path: "C:/source/puppet", :require => false
   end
 
   case RUBY_PLATFORM

--- a/lib/puppet-languageserver-sidecar/puppet_monkey_patches.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_monkey_patches.rb
@@ -29,12 +29,23 @@ module Puppet
 
         def monkey_append_function_info(name, value)
           @monkey_function_list = {} if @monkey_function_list.nil?
+
+          # Calculate function signature based on arity
+          # Ref: https://www.rubydoc.info/gems/puppet/Puppet/Parser/Functions#newfunction-class_method
+          # The [arity](en.wikipedia.org/wiki/Arity) of the function. When specified as a positive integer the function is expected to receive exactly the specified number
+          # of arguments. When specified as a negative number, the function is expected to receive _at least_ the absolute value of the specified number of arguments
+          # incremented by one. For example, a function with an arity of `-4` is expected to receive at minimum 3 arguments. A function with the default arity of `-1`
+          # accepts zero or more arguments. A function with an arity of 2 must be provided with exactly two arguments, no more and no less. Added in Puppet 3.1.0.
+          arg_count = value[:arity] < 0 ? (value[:arity] + 1) * -1 : value[:arity]
+          signature = name.to_s + '(' + (1..arg_count).map { |i| "Param#{i}" }.join(', ') + ')'
+
           @monkey_function_list[name] = {
-            :arity           => value[:arity],
             :name            => value[:name],
             :type            => value[:type],
             :doc             => value[:doc],
-            :source_location => value[:source_location]
+            :source_location => value[:source_location],
+            :signatures      => [signature],
+            :version         => 3
           }
         end
 
@@ -43,6 +54,76 @@ module Puppet
           @monkey_function_list.clone
         end
       end
+    end
+  end
+end
+
+# Add an additional method on Puppet Types to store their source location
+# require 'puppet/functions'
+# module Puppet
+#   class Function
+#     class << self
+#       attr_accessor :_yyysource_location
+#     end
+#   end
+# end
+
+module Puppet
+  module Functions
+    class << self
+      alias_method :original_create_function, :create_function
+    end
+
+    def self.create_function(func_name, function_base = Function, &block)
+      # See if we've hooked elsewhere. Also be specific about which function in the puppet_monkey_patches.rb we are looking for
+      # This can happen while in debuggers (pry). If we're not in the previous caller stack then just use the last caller
+      monkey_index = Kernel.caller_locations.find_index { |loc| loc.path.match(/puppet_monkey_patches\.rb/) && loc.label == 'create_function' }
+      monkey_index = -1 if monkey_index.nil?
+      caller = Kernel.caller_locations[monkey_index + 1]
+      # Call the original new function method
+      result = original_create_function(func_name, function_base, &block)
+
+      monkey_append_function_info(result.name, result,
+                                  :source_location => {
+                                    :source => caller.absolute_path,
+                                    :line   => caller.lineno - 1 # Convert to a zero based line number system
+                                  })
+
+      result
+    end
+
+    def self.monkey_clear_function_info
+      @monkey_function_list = {}
+    end
+
+    def self.monkey_append_function_info(name, value, options = {})
+      @monkey_function_list = {} if @monkey_function_list.nil?
+
+      # Generate the signature information
+      # TODO What about really long signatures?
+      # TODO What about params with no name? e.g. no param specified
+      signatures = value.signatures.map do |signature|
+        return_type = signature.type.return_type.nil? ? '' : "[#{signature.type.return_type}] "
+        params = []
+        signature.type.param_types.each_with_index do |param_type, idx|
+          params << "[#{param_type}] #{signature.param_names[idx]}"
+        end
+
+        "#{return_type}#{name}(#{params.join(', ')})"
+      end
+
+      @monkey_function_list[name] = {
+        :name       => value.name,
+        :signatures => signatures,
+        :type       => :rvalue, # All Puppet 4 functions will return a value
+        :doc        => nil, # Docs are filled in post processing via Yard
+        :version    => 4
+      }.merge(options)
+    end
+
+    def self.monkey_function_list
+      @monkey_function_list = {} if @monkey_function_list.nil?
+      @monkey_function_list.clone
     end
   end
 end
@@ -73,6 +154,69 @@ module Puppet
           }
         end
         result
+      end
+    end
+  end
+end
+
+# DEBUG PATCHING
+# module Puppet::Pops
+#   module Loader
+#     module ModuleLoaders
+#       class AbstractPathBasedModuleLoader
+#         alias_method :original_discover, :discover
+#         alias_method :original_find, :find
+
+#         def discover(type, error_collector = nil, name_authority = Pcore::RUNTIME_NAME_AUTHORITY, &block)
+#           puts "**************** discover Loader=#{self.loader_name} Type=#{type}"
+#           #return [] if self.loader_name == 'puppet_system'
+#           original_discover(type, error_collector, name_authority, &block)
+#         end
+
+#         def find(typed_name)
+#           puts "* find Loader=#{self.loader_name} typed_name.name=#{typed_name.name}"
+#           #require 'pry'; binding.pry if self.loader_name == 'puppetlabs-reboot' && typed_name.name == 'reboot::sleep'
+#           original_find(typed_name)
+#         end
+#       end
+#     end
+#   end
+# end
+
+# module Puppet::Pops
+#   module Loader
+#     class BaseLoader
+#       alias_method :original_load_typed, :load_typed
+#       alias_method :original_internal_load, :internal_load
+#       def load_typed(typed_name)
+#         puts "load_typed Loader=#{self.loader_name} Type=#{typed_name.name}"
+#         original_load_typed(typed_name)
+#       end
+
+#       def internal_load(typed_name)
+#         puts "internal_load Loader=#{self.loader_name} Type=#{typed_name.name}"
+#         original_internal_load(typed_name)
+#       end
+#     end
+#   end
+# end
+# DEBUG PATCHING
+
+# Due to PUP-9509 need to monkey patch the cache loader
+# TODO: Does this need to be guarded on Puppet version? e.g. this doesn't exist before 5.4.0
+module Puppet
+  module Pops
+    module Loader
+      module ModuleLoaders
+        def self.cached_loader_from(parent_loader, loaders)
+          LibRootedFileBased.new(parent_loader,
+            loaders,
+            NAMESPACE_WILDCARD,
+            Puppet[:libdir],
+            'cached_puppet_lib',
+            [:func_4x, :func_3x, :datatype]
+          )
+        end
       end
     end
   end

--- a/lib/puppet-languageserver-sidecar/puppet_monkey_patches_pup4api.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_monkey_patches_pup4api.rb
@@ -1,0 +1,43 @@
+# These monkey patches are only required when the pup4api feature flag is specified
+
+# The Ruby Legacy Function Instantiator doesn't have any error catching upon loading and would normally cause the entire puppet
+# run to fail.  However as we're a bit special, we can wrap the loader in rescue block and just continue on
+require 'puppet/pops/loader/ruby_legacy_function_instantiator'
+module Puppet
+  module Pops
+    module Loader
+      class RubyLegacyFunctionInstantiator
+        class << self
+          alias_method :original_create, :create
+        end
+
+        def self.create(loader, typed_name, source_ref, ruby_code_string)
+          self.original_create(loader, typed_name, source_ref, ruby_code_string)
+        rescue LoadError, StandardError => err
+          PuppetLanguageServerSidecar.log_message(:error, "[MonkeyPatch::Puppet::Pops::Loader::RubyLegacyFunctionInstantiator] Error loading legacy function #{typed_name.name}: #{err} #{err.backtrace}")
+        end
+      end
+    end
+  end
+end
+
+# The Ruby Function Instantiator doesn't have any error catching upon loading and would normally cause the entire puppet
+# run to fail.  However as we're a bit special, we can wrap the loader in rescue block and just continue on
+require 'puppet/pops/loader/ruby_function_instantiator'
+module Puppet
+  module Pops
+    module Loader
+      class RubyFunctionInstantiator
+        class << self
+          alias_method :original_create, :create
+        end
+
+        def self.create(loader, typed_name, source_ref, ruby_code_string)
+          self.original_create(loader, typed_name, source_ref, ruby_code_string)
+        rescue LoadError, StandardError => err
+          PuppetLanguageServerSidecar.log_message(:error, "[MonkeyPatch::Puppet::Pops::Loader::RubyLegacyFunctionInstantiator] Error loading function #{typed_name.name}: #{err} #{err.backtrace}")
+        end
+      end
+    end
+  end
+end

--- a/lib/puppet-languageserver-sidecar/puppet_pal.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_pal.rb
@@ -1,0 +1,546 @@
+# Puppet as a Library "PAL"
+
+# Yes, this requires all of puppet for now because 'settings' and many other things...
+require 'puppet'
+require 'puppet_pal'
+require 'puppet/parser/script_compiler'
+require 'puppet/parser/catalog_compiler'
+
+# Monkey Patch the PAL Compiler to surface some private details
+# TODO Instead of monkey patch create our own Compiler PESCompiler
+module Puppet
+  module Pal
+    class Compiler
+      def public_compiler
+        internal_compiler
+      end
+
+      def public_list_loadable_kind(kind, filter_regex = nil, error_collector = nil)
+        list_loadable_kind(kind, filter_regex, error_collector)
+      end
+    end
+  end
+end
+
+# As this is a copy of the Puppet PAL code, ignore any rubocop violations
+# rubocop:disable all
+
+# TODO: instead of copying this code, perhaps figure out how to have our own compiler stuff.
+#---
+
+# This is the main entry point for "Puppet As a Library" PAL.
+# This file should be required instead of "puppet"
+# Initially, this will require ALL of puppet - over time this will change as the monolithical "puppet" is broken up
+# into smaller components.
+#
+# @example Running a snippet of Puppet Language code
+#   require 'puppet_pal'
+#   result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: ['/tmp/testmodules']) do |pal|
+#     pal.evaluate_script_string('1+2+3')
+#   end
+#   # The result is the value 6
+#
+# @example Calling a function
+#   require 'puppet_pal'
+#   result = Puppet::Pal.in_tmp_environment('pal_env', modulepath: ['/tmp/testmodules']) do |pal|
+#     pal.call_function('mymodule::myfunction', 10, 20)
+#   end
+#   # The result is what 'mymodule::myfunction' returns
+#
+module Puppet
+module PalV2
+
+  # Defines a context in which multiple operations in an env with a script compiler can be performed in a given block.
+  # The calls that takes place to PAL inside of the given block are all with the same instance of the compiler.
+  # The parameter `configured_by_env` makes it possible to either use the configuration in the environment, or specify
+  # `manifest_file` or `code_string` manually. If neither is given, an empty `code_string` is used.
+  #
+  # @example define a script compiler without any initial logic
+  #   pal.with_script_compiler do | compiler |
+  #     # do things with compiler
+  #   end
+  #
+  # @example define a script compiler with a code_string containing initial logic
+  #   pal.with_script_compiler(code_string: '$myglobal_var = 42')  do | compiler |
+  #     # do things with compiler
+  #   end
+  #
+  # @param configured_by_env [Boolean] when true the environment's settings are used, otherwise the given `manifest_file` or `code_string`
+  # @param manifest_file [String] a Puppet Language file to load and evaluate before calling the given block, mutually exclusive with `code_string`
+  # @param code_string [String] a Puppet Language source string to load and evaluate before calling the given block, mutually exclusive with `manifest_file`
+  # @param facts [Hash] optional map of fact name to fact value - if not given will initialize the facts (which is a slow operation)
+  #   If given at the environment level, the facts given here are merged with higher priority.
+  # @param variables [Hash] optional map of fully qualified variable name to value. If given at the environment level, the variables
+  #   given here are merged with higher priority.
+  # @param block [Proc] the block performing operations on compiler
+  # @return [Object] what the block returns
+  # @yieldparam [Puppet::Pal::ScriptCompiler] compiler, a ScriptCompiler to perform operations on.
+  #
+  def self.with_script_compiler(
+      configured_by_env: false,
+      manifest_file:     nil,
+      code_string:       nil,
+      facts:             nil,
+      variables:         nil,
+      for_agent:         false,
+      &block
+    )
+    # TRANSLATORS: do not translate variable name strings in these assertions
+    assert_mutually_exclusive(manifest_file, code_string, 'manifest_file', 'code_string')
+    assert_non_empty_string(manifest_file, 'manifest_file', true)
+    assert_non_empty_string(code_string, 'code_string', true)
+    assert_type(T_BOOLEAN, configured_by_env, "configured_by_env", false)
+
+    if configured_by_env
+      unless manifest_file.nil? && code_string.nil?
+        # TRANSLATORS: do not translate the variable names in this error message
+        raise ArgumentError, _("manifest_file or code_string cannot be given when configured_by_env is true")
+      end
+      # Use the manifest setting
+      manifest_file = Puppet[:manifest]
+    else
+      # An "undef" code_string is the only way to override Puppet[:manifest] & Puppet[:code] settings since an
+      # empty string is taken as Puppet[:code] not being set.
+      #
+      if manifest_file.nil? && code_string.nil?
+        code_string = 'undef'
+      end
+    end
+
+    Puppet[:tasks] = true
+    # After the assertions, if code_string is non nil - it has the highest precedence
+    Puppet[:code] = code_string unless code_string.nil?
+
+    # If manifest_file is nil, the #main method will use the env configured manifest
+    # to do things in the block while a Script Compiler is in effect
+    main(manifest_file, facts, variables, :script, for_agent, &block)
+  end
+
+  # Evaluates a Puppet Language script string.
+  # @param code_string [String] a snippet of Puppet Language source code
+  # @return [Object] what the Puppet Language code_string evaluates to
+  # @deprecated Use {#with_script_compiler} and then evaluate_string on the given compiler - to be removed in 1.0 version
+  #
+  def self.evaluate_script_string(code_string)
+    # prevent the default loading of Puppet[:manifest] which is the environment's manifest-dir by default settings
+    # by setting code_string to 'undef'
+    with_script_compiler do |compiler|
+      compiler.evaluate_string(code_string)
+    end
+  end
+
+  # Evaluates a Puppet Language script (.pp) file.
+  # @param manifest_file [String] a file with Puppet Language source code
+  # @return [Object] what the Puppet Language manifest_file contents evaluates to
+  # @deprecated Use {#with_script_compiler} and then evaluate_file on the given compiler - to be removed in 1.0 version
+  #
+  def self.evaluate_script_manifest(manifest_file)
+    with_script_compiler do |compiler|
+      compiler.evaluate_file(manifest_file)
+    end
+  end
+
+  # Defines a context in which multiple operations in an env with a catalog producing compiler can be performed
+  # in a given block.
+  # The calls that takes place to PAL inside of the given block are all with the same instance of the compiler.
+  # The parameter `configured_by_env` makes it possible to either use the configuration in the environment, or specify
+  # `manifest_file` or `code_string` manually. If neither is given, an empty `code_string` is used.
+  #
+  # @example define a catalog compiler without any initial logic
+  #   pal.with_catalog_compiler do | compiler |
+  #     # do things with compiler
+  #   end
+  #
+  # @example define a catalog compiler with a code_string containing initial logic
+  #   pal.with_catalog_compiler(code_string: '$myglobal_var = 42')  do | compiler |
+  #     # do things with compiler
+  #   end
+  #
+  # @param configured_by_env [Boolean] when true the environment's settings are used, otherwise the
+  #   given `manifest_file` or `code_string`
+  # @param manifest_file [String] a Puppet Language file to load and evaluate before calling the given block, mutually exclusive
+  #   with `code_string`
+  # @param code_string [String] a Puppet Language source string to load and evaluate before calling the given block, mutually
+  #   exclusive with `manifest_file`
+  # @param facts [Hash] optional map of fact name to fact value - if not given will initialize the facts (which is a slow operation)
+  #   If given at the environment level, the facts given here are merged with higher priority.
+  # @param variables [Hash] optional map of fully qualified variable name to value. If given at the environment level, the variables
+  #   given here are merged with higher priority.
+  # @param block [Proc] the block performing operations on compiler
+  # @return [Object] what the block returns
+  # @yieldparam [Puppet::Pal::CatalogCompiler] compiler, a CatalogCompiler to perform operations on.
+  #
+  def self.with_catalog_compiler(
+    configured_by_env: false,
+      manifest_file:     nil,
+      code_string:       nil,
+      facts:             nil,
+      variables:         nil,
+      &block
+  )
+    # TRANSLATORS: do not translate variable name strings in these assertions
+    assert_mutually_exclusive(manifest_file, code_string, 'manifest_file', 'code_string')
+    assert_non_empty_string(manifest_file, 'manifest_file', true)
+    assert_non_empty_string(code_string, 'code_string', true)
+    assert_type(T_BOOLEAN, configured_by_env, "configured_by_env", false)
+
+    if configured_by_env
+      unless manifest_file.nil? && code_string.nil?
+        # TRANSLATORS: do not translate the variable names in this error message
+        raise ArgumentError, _("manifest_file or code_string cannot be given when configured_by_env is true")
+      end
+      # Use the manifest setting
+      manifest_file = Puppet[:manifest]
+    else
+      # An "undef" code_string is the only way to override Puppet[:manifest] & Puppet[:code] settings since an
+      # empty string is taken as Puppet[:code] not being set.
+      #
+      if manifest_file.nil? && code_string.nil?
+        code_string = 'undef'
+      end
+    end
+
+    Puppet[:tasks] = false
+    # After the assertions, if code_string is non nil - it has the highest precedence
+    Puppet[:code] = code_string unless code_string.nil?
+
+    # If manifest_file is nil, the #main method will use the env configured manifest
+    # to do things in the block while a Script Compiler is in effect
+    main(manifest_file, facts, variables, :catalog, &block)
+  end
+
+  # Defines the context in which to perform puppet operations (evaluation, etc)
+  # The code to evaluate in this context is given in a block.
+  #
+  # @param env_name [String] a name to use for the temporary environment - this only shows up in errors
+  # @param modulepath [Array<String>] an array of directory paths containing Puppet modules, may be empty, defaults to empty array
+  # @param settings_hash [Hash] a hash of settings - currently not used for anything, defaults to empty hash
+  # @param facts [Hash] optional map of fact name to fact value - if not given will initialize the facts (which is a slow operation)
+  # @param variables [Hash] optional map of fully qualified variable name to value
+  # @return [Object] returns what the given block returns
+  # @yieldparam [Puppet::Pal] context, a context that responds to Puppet::Pal methods
+  #
+  def self.in_tmp_environment(env_name,
+      modulepath:    [],
+      settings_hash: {},
+      facts:         nil,
+      variables:     {},
+      &block
+    )
+    assert_non_empty_string(env_name, _("temporary environment name"))
+    # TRANSLATORS: do not translate variable name string in these assertions
+    assert_optionally_empty_array(modulepath, 'modulepath')
+
+    unless block_given?
+      raise ArgumentError, _("A block must be given to 'in_tmp_environment'") # TRANSLATORS 'in_tmp_environment' is a name, do not translate
+    end
+
+    env = Puppet::Node::Environment.create(env_name, modulepath)
+
+    in_environment_context(
+      Puppet::Environments::Static.new(env), # The tmp env is the only known env
+      env, facts, variables, &block
+      )
+  end
+
+  # Defines the context in which to perform puppet operations (evaluation, etc)
+  # The code to evaluate in this context is given in a block.
+  #
+  # The name of an environment (env_name) is always given. The location of that environment on disk
+  # is then either constructed by:
+  # * searching a given envpath where name is a child of a directory on that path, or
+  # * it is the directory given in env_dir (which must exist).
+  #
+  # The env_dir and envpath options are mutually exclusive.
+  #
+  # @param env_name [String] the name of an existing environment
+  # @param modulepath [Array<String>] an array of directory paths containing Puppet modules, overrides the modulepath of an existing env.
+  #   Defaults to `{env_dir}/modules` if `env_dir` is given,
+  # @param pre_modulepath [Array<String>] like modulepath, but is prepended to the modulepath
+  # @param post_modulepath [Array<String>] like modulepath, but is appended to the modulepath
+  # @param settings_hash [Hash] a hash of settings - currently not used for anything, defaults to empty hash
+  # @param env_dir [String] a reference to a directory being the named environment (mutually exclusive with `envpath`)
+  # @param envpath [String] a path of directories in which there are environments to search for `env_name` (mutually exclusive with `env_dir`).
+  #   Should be a single directory, or several directories separated with platform specific `File::PATH_SEPARATOR` character.
+  # @param facts [Hash] optional map of fact name to fact value - if not given will initialize the facts (which is a slow operation)
+  # @param variables [Hash] optional map of fully qualified variable name to value
+  # @return [Object] returns what the given block returns
+  # @yieldparam [Puppet::Pal] context, a context that responds to Puppet::Pal methods
+  #
+  def self.in_environment(env_name,
+      modulepath:    nil,
+      pre_modulepath: [],
+      post_modulepath: [],
+      settings_hash: {},
+      env_dir:       nil,
+      envpath:       nil,
+      facts:         nil,
+      variables:     {},
+      &block
+    )
+    # TRANSLATORS terms in the assertions below are names of terms in code
+    assert_non_empty_string(env_name, 'env_name')
+    assert_optionally_empty_array(modulepath, 'modulepath', true)
+    assert_optionally_empty_array(pre_modulepath, 'pre_modulepath', false)
+    assert_optionally_empty_array(post_modulepath, 'post_modulepath', false)
+    assert_mutually_exclusive(env_dir, envpath, 'env_dir', 'envpath')
+
+    unless block_given?
+      raise ArgumentError, _("A block must be given to 'in_environment'") # TRANSLATORS 'in_environment' is a name, do not translate
+    end
+
+    if env_dir
+      unless Puppet::FileSystem.exist?(env_dir)
+        raise ArgumentError, _("The environment directory '%{env_dir}' does not exist") % { env_dir: env_dir }
+      end
+
+      # a nil modulepath for env_dir means it should use its ./modules directory
+      mid_modulepath = modulepath.nil? ? [Puppet::FileSystem.expand_path(File.join(env_dir, 'modules'))] : modulepath
+
+      env = Puppet::Node::Environment.create(env_name, pre_modulepath + mid_modulepath + post_modulepath)
+      environments = Puppet::Environments::StaticDirectory.new(env_name, env_dir, env) # The env being used is the only one...
+    else
+      assert_non_empty_string(envpath, 'envpath')
+
+      # The environment is resolved against the envpath. This is setup without a basemodulepath
+      # The modulepath defaults to the 'modulepath' in the found env when "Directories" is used
+      #
+      if envpath.is_a?(String) && envpath.include?(File::PATH_SEPARATOR)
+        # potentially more than one directory to search
+        env_loaders = Puppet::Environments::Directories.from_path(envpath, [])
+        environments = Puppet::Environments::Combined.new(*env_loaders)
+      else
+        environments = Puppet::Environments::Directories.new(envpath, [])
+      end
+      env = environments.get(env_name)
+      if env.nil?
+        raise ArgumentError, _("No directory found for the environment '%{env_name}' on the path '%{envpath}'") % { env_name: env_name, envpath: envpath }
+      end
+      # A given modulepath should override the default
+      mid_modulepath = modulepath.nil? ? env.modulepath : modulepath
+      env_path = env.configuration.path_to_env
+      env = env.override_with(:modulepath => pre_modulepath + mid_modulepath + post_modulepath)
+      # must configure this in case logic looks up the env by name again (otherwise the looked up env does
+      # not have the same effective modulepath).
+      environments = Puppet::Environments::StaticDirectory.new(env_name, env_path, env) # The env being used is the only one...
+    end
+    in_environment_context(environments, env, facts, variables, &block)
+  end
+
+  # Prepares the puppet context with pal information - and delegates to the block
+  # No set up is performed at this step - it is delayed until it is known what the
+  # operation is going to be (for example - using a ScriptCompiler).
+  #
+  def self.in_environment_context(environments, env, facts, variables, &block)
+    # Create a default node to use (may be overridden later)
+    node = Puppet::Node.new(Puppet[:node_name_value], :environment => env)
+
+    Puppet.override(
+      environments: environments,     # The env being used is the only one...
+      pal_env: env,                   # provide as convenience
+      pal_current_node: node,         # to allow it to be picked up instead of created
+      pal_variables: variables,       # common set of variables across several inner contexts
+      pal_facts: facts                # common set of facts across several inner contexts (or nil)
+    ) do
+      # DELAY: prepare_node_facts(node, facts)
+      return block.call(self)
+    end
+  end
+  private_class_method :in_environment_context
+
+  # Prepares the node for use by giving it node_facts (if given)
+  # If a hash of facts values is given, then the operation of creating a node with facts is much
+  # speeded up (as getting a fresh set of facts is avoided in a later step).
+  #
+  def self.prepare_node_facts(node, facts)
+    # Prepare the node with facts if it does not already have them
+    if node.facts.nil?
+      node_facts = facts.nil? ? nil : Puppet::Node::Facts.new(Puppet[:node_name_value], facts)
+      node.fact_merge(node_facts)
+      # Add server facts so $server_facts[environment] exists when doing a puppet script
+      # SCRIPT TODO: May be needed when running scripts under orchestrator. Leave it for now.
+      #
+      node.add_server_facts({})
+    end
+  end
+  private_class_method :prepare_node_facts
+
+  def self.add_variables(scope, variables)
+    return if variables.nil?
+    unless variables.is_a?(Hash)
+      raise ArgumentError, _("Given variables must be a hash, got %{type}") % { type: variables.class }
+    end
+
+    rich_data_t = Puppet::Pops::Types::TypeFactory.rich_data
+    variables.each_pair do |k,v|
+      unless k =~ Puppet::Pops::Patterns::VAR_NAME
+        raise ArgumentError, _("Given variable '%{varname}' has illegal name") % { varname: k }
+      end
+
+      unless rich_data_t.instance?(v)
+        raise ArgumentError, _("Given value for '%{varname}' has illegal type - got: %{type}") % { varname: k, type: v.class }
+      end
+
+      scope.setvar(k, v)
+    end
+  end
+  private_class_method :add_variables
+
+  # The main routine for script compiler
+  # Picks up information from the puppet context and configures a script compiler which is given to
+  # the provided block
+  #
+  def self.main(manifest, facts, variables, internal_compiler_class, for_agent = false)
+    # Configure the load path
+    env = Puppet.lookup(:pal_env)
+    env.each_plugin_directory do |dir|
+      $LOAD_PATH << dir unless $LOAD_PATH.include?(dir)
+    end
+
+    # Puppet requires Facter, which initializes its lookup paths. Reset Facter to
+    # pickup the new $LOAD_PATH.
+    Facter.reset
+
+    node = Puppet.lookup(:pal_current_node)
+    pal_facts = Puppet.lookup(:pal_facts)
+    pal_variables = Puppet.lookup(:pal_variables)
+
+    overrides = {}
+    unless facts.nil? || facts.empty?
+      pal_facts = pal_facts.merge(facts)
+      overrides[:pal_facts] = pal_facts
+    end
+    unless variables.nil? || variables.empty?
+      pal_variables = pal_variables.merge(variables)
+      overrides[:pal_variables] = pal_variables
+    end
+
+    prepare_node_facts(node, pal_facts)
+
+    configured_environment = node.environment || Puppet.lookup(:current_environment)
+
+    apply_environment = manifest ?
+      configured_environment.override_with(:manifest => manifest) :
+      configured_environment
+
+    # Modify the node descriptor to use the special apply_environment.
+    # It is based on the actual environment from the node, or the locally
+    # configured environment if the node does not specify one.
+    # If a manifest file is passed on the command line, it overrides
+    # the :manifest setting of the apply_environment.
+    node.environment = apply_environment
+
+    # TRANSLATORS, the string "For puppet PAL" is not user facing
+    Puppet.override({:current_environment => apply_environment}, "For puppet PAL") do
+      begin
+        # support the following features when evaluating puppet code
+        # * $facts with facts from host running the script
+        # * $settings with 'settings::*' namespace populated, and '$settings::all_local' hash
+        # * $trusted as setup when using puppet apply
+        # * an environment
+        #
+
+        # fixup trusted information
+        node.sanitize()
+
+        compiler = create_internal_compiler(internal_compiler_class, node, for_agent)
+        topscope = compiler.topscope
+
+        # When scripting the trusted data are always local, but set them anyway
+        # When compiling for a catalog, the catalog compiler does this
+        unless internal_compiler_class == :catalog
+          topscope.set_trusted(node.trusted_data)
+
+          # Server facts are always about the local node's version etc.
+          topscope.set_server_facts(node.server_facts)
+
+          # Set $facts for the node running the script
+          facts_hash = node.facts.nil? ? {} : node.facts.values
+          topscope.set_facts(facts_hash)
+
+          # create the $settings:: variables
+          topscope.merge_settings(node.environment.name, false)
+        end
+
+        add_variables(topscope, pal_variables)
+
+        case internal_compiler_class
+        when :script
+          pal_compiler = Puppet::Pal::ScriptCompiler.new(compiler)
+          overrides[:pal_script_compiler] = overrides[:pal_compiler] = pal_compiler
+        when :catalog
+          pal_compiler = Puppet::Pal::CatalogCompiler.new(compiler)
+          overrides[:pal_catalog_compiler] = overrides[:pal_compiler] = pal_compiler
+        end
+
+        # Make compiler available to Puppet#lookup and injection in functions
+        # TODO: The compiler instances should be available under non PAL use as well!
+        # TRANSLATORS: Do not translate, symbolic name
+        Puppet.override(overrides, "PAL::with_#{internal_compiler_class}_compiler") do
+          compiler.compile do | compiler_yield |
+            # wrap the internal compiler to prevent it from leaking in the PAL API
+            if block_given?
+              yield(pal_compiler)
+            end
+          end
+        end
+
+      rescue Puppet::ParseErrorWithIssue, Puppet::Error
+        # already logged and handled by the compiler for these two cases
+        raise
+
+      rescue => detail
+        Puppet.log_exception(detail)
+        raise
+      end
+    end
+  end
+  private_class_method :main
+
+  def self.create_internal_compiler(compiler_class_reference, node, for_agent = false)
+    case compiler_class_reference
+    when :script
+      Puppet::Parser::ScriptCompiler.new(node.environment, node.name, for_agent)
+    when :catalog
+      Puppet::Parser::CatalogCompiler.new(node)
+    else
+      raise ArgumentError, "Internal Error: Invalid compiler type requested."
+    end
+  end
+
+  T_STRING = Puppet::Pops::Types::PStringType::NON_EMPTY
+  T_STRING_ARRAY = Puppet::Pops::Types::TypeFactory.array_of(T_STRING)
+  T_ANY_ARRAY = Puppet::Pops::Types::TypeFactory.array_of_any
+  T_BOOLEAN = Puppet::Pops::Types::PBooleanType::DEFAULT
+
+  T_GENERIC_TASK_HASH = Puppet::Pops::Types::TypeFactory.hash_kv(
+    Puppet::Pops::Types::TypeFactory.pattern(/\A[a-z][a-z0-9_]*\z/), Puppet::Pops::Types::TypeFactory.data)
+
+  def self.assert_type(type, value, what, allow_nil=false)
+    Puppet::Pops::Types::TypeAsserter.assert_instance_of(nil, type, value, allow_nil) { _('Puppet Pal: %{what}') % {what: what} }
+  end
+
+  def self.assert_non_empty_string(s, what, allow_nil=false)
+    assert_type(T_STRING, s, what, allow_nil)
+  end
+
+  def self.assert_optionally_empty_array(a, what, allow_nil=false)
+    assert_type(T_STRING_ARRAY, a, what, allow_nil)
+  end
+  private_class_method :assert_optionally_empty_array
+
+  def self.assert_mutually_exclusive(a, b, a_term, b_term)
+    if a && b
+      raise ArgumentError, _("Cannot use '%{a_term}' and '%{b_term}' at the same time") % { a_term: a_term, b_term: b_term }
+    end
+  end
+  private_class_method :assert_mutually_exclusive
+
+  def self.assert_block_given(block)
+    if block.nil?
+      raise ArgumentError, _("A block must be given")
+    end
+  end
+  private_class_method :assert_block_given
+end
+end

--- a/lib/puppet-languageserver-sidecar/sidecar_protocol_extensions.rb
+++ b/lib/puppet-languageserver-sidecar/sidecar_protocol_extensions.rb
@@ -41,10 +41,10 @@ module PuppetLanguageServerSidecar
         obj.source         = item[:source_location][:source]
         obj.calling_source = obj.source
         obj.line           = item[:source_location][:line]
-        # TODO: name ?
-        obj.doc   = item[:doc]
-        obj.arity = item[:arity]
-        obj.type  = item[:type]
+        obj.doc            = item[:doc]
+        obj.signatures     = item[:signatures]
+        obj.type           = item[:type]
+        obj.version        = item[:version]
         obj
       end
     end

--- a/lib/puppet-languageserver/manifest/completion_provider.rb
+++ b/lib/puppet-languageserver/manifest/completion_provider.rb
@@ -202,11 +202,13 @@ module PuppetLanguageServer
           item_type = PuppetLanguageServer::PuppetHelper.function(data['name'])
           return LanguageServer::CompletionItem.create(result) if item_type.nil?
           result['documentation'] = item_type.doc unless item_type.doc.nil?
-          result['insertText'] = "#{data['name']}(${1:value}"
-          (2..item_type.arity).each do |index|
-            result['insertText'] += ", ${#{index}:value}"
-          end
-          result['insertText'] += ')'
+          # TODO: Add signatures?
+          result['insertText'] = item_type.signatures[0] unless item_type.signatures.empty?
+          # result['insertText'] = "#{data['name']}(${1:value}"
+          # (2..item_type.arity).each do |index|
+          #   result['insertText'] += ", ${#{index}:value}"
+          # end
+          # result['insertText'] += ')'
           result['insertTextFormat'] = LanguageServer::INSERTTEXTFORMAT_SNIPPET
 
         when 'resource_type'

--- a/lib/puppet-languageserver/puppet_helper/cache_objects.rb
+++ b/lib/puppet-languageserver/puppet_helper/cache_objects.rb
@@ -40,14 +40,16 @@ module PuppetLanguageServer
 
     class PuppetFunction < BasePuppetObject
       attr_accessor :doc
-      attr_accessor :arity
       attr_accessor :type
+      attr_accessor :version
+      attr_accessor :signatures
 
       def from_sidecar!(value)
         super
         @doc = value.doc
-        @arity = value.arity
         @type = value.type
+        @version = value.version
+        @signatures = value.signatures
         self
       end
     end

--- a/lib/puppet-languageserver/sidecar_protocol.rb
+++ b/lib/puppet-languageserver/sidecar_protocol.rb
@@ -114,6 +114,18 @@ module PuppetLanguageServer
         end
       end
 
+      class CompiledPuppetInformation
+        include Base
+
+        attr_accessor :functions
+
+        # def to_json(*options)
+        # end
+
+        # def from_json!(json_string)
+        # end
+      end
+
       class PuppetClass < BasePuppetObject
         attr_accessor :parameters
         attr_accessor :doc
@@ -150,14 +162,16 @@ module PuppetLanguageServer
 
       class PuppetFunction < BasePuppetObject
         attr_accessor :doc
-        attr_accessor :arity
         attr_accessor :type
+        attr_accessor :version
+        attr_accessor :signatures
 
         def to_h
           super.to_h.merge(
-            'doc'   => doc,
-            'arity' => arity,
-            'type'  => type
+            'doc'        => doc,
+            'type'       => type,
+            'version'    => version,
+            'signatures' => signatures
           )
         end
 
@@ -165,8 +179,9 @@ module PuppetLanguageServer
           super
 
           self.doc = value['doc']
-          self.arity = value['arity']
           self.type = value['type'].intern
+          self.version = value['version']
+          self.signatures = value['signatures']
           self
         end
       end

--- a/lib/puppet_languageserver_sidecar.rb
+++ b/lib/puppet_languageserver_sidecar.rb
@@ -254,7 +254,7 @@ module PuppetLanguageServerSidecar
       STDOUT.binmode
       STDOUT.write(result.to_json)
     else
-      File.open(options[:output], 'wb:UTF8') do |f|
+      File.open(options[:output], 'wb:UTF-8') do |f|
         f.write result.to_json
       end
     end

--- a/spec/languageserver-sidecar/fixtures/real_agent/cache/lib/puppet/functions/default_pup4_function.rb
+++ b/spec/languageserver-sidecar/fixtures/real_agent/cache/lib/puppet/functions/default_pup4_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API
+# This should be loaded
+Puppet::Functions.create_function(:default_pup4_function) do
+  # @return [Array<String>]
+  def default_pup4_function
+    'default_pup4_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/real_agent/cache/lib/puppet/functions/environment/default_env_pup4_function.rb
+++ b/spec/languageserver-sidecar/fixtures/real_agent/cache/lib/puppet/functions/environment/default_env_pup4_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API
+# This should be loaded in the environment namespace
+Puppet::Functions.create_function(:default_env_pup4_function) do
+  # @return [Array<String>]
+  def default_env_pup4_function
+    'default_env_pup4_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/real_agent/cache/lib/puppet/functions/modname/default_mod_pup4_function.rb
+++ b/spec/languageserver-sidecar/fixtures/real_agent/cache/lib/puppet/functions/modname/default_mod_pup4_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API
+# This should be loaded in the module called 'modname' namespace
+Puppet::Functions.create_function(:'modname::default_mod_pup4_function') do
+  # @return [Array<String>]
+  def default_mod_pup4_function
+    'default_env_pup4_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/badname/pup4_function.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/badname/pup4_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API in a module
+# This should not be loaded in the environment namespace
+Puppet::Functions.create_function(:'badname::pup4_function') do
+  # @return [Array<String>]
+  def pup4_function
+    'pup4_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/profile/pup4_envprofile_function.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/profile/pup4_envprofile_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API in a module
+# This should be loaded in the module namespace
+Puppet::Functions.create_function(:'profile::pup4_envprofile_function') do
+  # @return [Array<String>]
+  def pup4_envprofile_function
+    'pup4_envprofile_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/pup4_env_badfile.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/pup4_env_badfile.rb
@@ -1,0 +1,10 @@
+require 'a_bad_gem_that_does_not_exist'
+
+# Example function using the Puppet 4 API in a module
+# This should not be loaded
+Puppet::Functions.create_function(:pup4_env_badfile) do
+  # @return [Array<String>]
+  def pup4_env_badfile
+    'pup4_env_badfile result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/pup4_env_badfunction.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/pup4_env_badfunction.rb
@@ -1,0 +1,9 @@
+# Example function using the Puppet 4 API in a module
+# This should be loaded but never actually successfully invoke
+Puppet::Functions.create_function(:pup4_env_badfunction) do
+  # @return [Array<String>]
+  def pup4_env_badfunction
+    require 'a_bad_gem_that_does_not_exist'
+    'pup4_env_badfunction result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/pup4_env_function.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/pup4_env_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API in a module
+# ??? This should be loaded as global namespace function
+Puppet::Functions.create_function(:pup4_env_function) do
+  # @return [Array<String>]
+  def pup4_env_function
+    'pup4_env_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/badname/fixture_pup4_env_function.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/badname/fixture_pup4_env_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API in a module
+# This should not be loaded in the module namespace
+Puppet::Functions.create_function(:'badname::fixture_pup4_badname_function') do
+  # @return [Array<String>]
+  def fixture_pup4_badname_function
+    'fixture_pup4_badname_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/fixture_pup4_badfile.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/fixture_pup4_badfile.rb
@@ -1,0 +1,10 @@
+require 'a_bad_gem_that_does_not_exist'
+
+# Example function using the Puppet 4 API in a module
+# This should not be loaded
+Puppet::Functions.create_function(:fixture_pup4_badfile) do
+  # @return [Array<String>]
+  def fixture_pup4_badfile
+    'fixture_pup4_badfile result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/fixture_pup4_badfunction.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/fixture_pup4_badfunction.rb
@@ -1,0 +1,9 @@
+# Example function using the Puppet 4 API in a module
+# This should be loaded but never actually successfully invoke
+Puppet::Functions.create_function(:fixture_pup4_badfunction) do
+  # @return [Array<String>]
+  def fixture_pup4_badfunction
+    require 'a_bad_gem_that_does_not_exist'
+    'fixture_pup4_badfunction result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/fixture_pup4_function.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/fixture_pup4_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API in a module
+# This should be loaded as global namespace function
+Puppet::Functions.create_function(:fixture_pup4_function) do
+  # @return [Array<String>]
+  def fixture_pup4_function
+    'fixture_pup4_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/valid/fixture_pup4_mod_function.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/valid/fixture_pup4_mod_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API in a module
+# This should be loaded in the module namespace
+Puppet::Functions.create_function(:'valid::fixture_pup4_mod_function') do
+  # @return [Array<String>]
+  def fixture_pup4_mod_function
+    'fixture_pup4_mod_function result'
+  end
+end

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_pup4api/featureflag_pup4api_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_pup4api/featureflag_pup4api_spec.rb
@@ -1,0 +1,152 @@
+require 'spec_helper'
+require 'open3'
+require 'tempfile'
+
+describe 'PuppetLanguageServerSidecar with Feature Flag pup4api', :if => PuppetLanguageServerSidecar.puppet_pal_supported? do
+  def run_sidecar(cmd_options)
+    cmd_options << '--no-cache'
+
+    # Append the feature flag
+    cmd_options << '--feature-flag=pup4api'
+
+    # Append the puppet test-fixtures
+    cmd_options << '--puppet-settings'
+    cmd_options << "--vardir,#{File.join($fixtures_dir, 'real_agent', 'cache')},--confdir,#{File.join($fixtures_dir, 'real_agent', 'confdir')}"
+
+    cmd = ['ruby', 'puppet-languageserver-sidecar'].concat(cmd_options)
+# DEBUG
+puts cmd.join(' ')
+    stdout, _stderr, status = Open3.capture3(*cmd)
+
+    raise "Expected exit code of 0, but got #{status.exitstatus} #{_stderr}" unless status.exitstatus.zero?
+    return stdout.bytes.pack('U*')
+  end
+
+  def child_with_key(array, key)
+    idx = array.index { |item| item.key == key }
+    return idx.nil? ? nil : array[idx]
+  end
+
+  def with_temporary_file(content)
+    tempfile = Tempfile.new("langserver-sidecar")
+    tempfile.open
+
+    tempfile.write(content)
+
+    tempfile.close
+
+    yield tempfile.path
+  ensure
+    tempfile.delete if tempfile
+  end
+
+  RSpec::Matchers.define :contain_child_with_key do |key|
+    match do |actual|
+      !(actual.index { |item| item.key == key }).nil?
+    end
+
+    failure_message do |actual|
+      "expected that #{actual.class.to_s} would contain a child with key #{key}"
+    end
+  end
+
+  describe 'when running default_functions action' do
+    let (:cmd_options) { ['--action', 'default_functions'] }
+
+    it 'should return a deserializable function list with default functions' do
+      result = run_sidecar(cmd_options)
+      deserial = PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionList.new()
+      expect { deserial.from_json!(result) }.to_not raise_error
+
+      expect(deserial.count).to be > 0
+
+      # These functions always exist
+      expect(deserial).to contain_child_with_key(:notice)
+      expect(deserial).to contain_child_with_key(:alert)
+
+      # These are defined in the fixtures/real_agent/cache/lib/puppet/parser/functions
+      expect(deserial).to contain_child_with_key(:default_cache_function)
+      # These are defined in the fixtures/real_agent/cache/lib/puppet/functions
+      expect(deserial).to contain_child_with_key(:default_pup4_function)
+      # These are defined in the fixtures/real_agent/cache/lib/puppet/functions/environment (Special environent namespace)
+      expect(deserial).to contain_child_with_key(:default_env_pup4_function)
+      # These are defined in the fixtures/real_agent/cache/lib/puppet/functions/modname (module namespaced function)
+      expect(deserial).to contain_child_with_key(:'modname::default_mod_pup4_function')
+    end
+  end
+
+  context 'given a workspace containing a module' do
+    # Test fixtures used is fixtures/valid_module_workspace
+    let(:workspace) { File.join($fixtures_dir, 'valid_module_workspace') }
+
+    describe 'when running workspace_functions action' do
+      let (:cmd_options) { ['--action', 'workspace_functions', '--local-workspace', workspace] }
+
+      it 'should return a deserializable function list with the named fixtures' do
+        result = run_sidecar(cmd_options)
+        deserial = PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionList.new()
+        expect { deserial.from_json!(result) }.to_not raise_error
+
+        # Puppet 3 API Functions
+        expect(deserial).to_not contain_child_with_key(:badfile)
+        expect(deserial).to contain_child_with_key(:bad_function)
+        expect(deserial).to contain_child_with_key(:fixture_function)
+
+        # Puppet 4 API Functions
+        expect(deserial).to_not contain_child_with_key(:fixture_pup4_badfile)
+        expect(deserial).to_not contain_child_with_key(:'badname::fixture_pup4_badname_function')
+        expect(deserial).to contain_child_with_key(:fixture_pup4_function)
+        expect(deserial).to contain_child_with_key(:'valid::fixture_pup4_mod_function')
+        expect(deserial).to contain_child_with_key(:fixture_pup4_badfunction)
+
+        # Make sure the function has the right properties
+        func = child_with_key(deserial, :fixture_function)
+        expect(func.doc).to eq('doc_fixture_function')
+        expect(func.source).to match(/valid_module_workspace/)
+        expect(func.version).to eq(3)
+
+        # Make sure the function has the right properties
+        func = child_with_key(deserial, :fixture_pup4_function)
+        expect(func.doc).to be_nil  # Currently we can't get the documentation for v4 functions
+        expect(func.source).to match(/valid_module_workspace/)
+        expect(func.version).to eq(4)
+        expect(func.signatures).to_not be_nil
+      end
+    end
+  end
+
+  context 'given a workspace containing an environment.conf' do
+    # Test fixtures used is fixtures/valid_environment_workspace
+    let(:workspace) { File.join($fixtures_dir, 'valid_environment_workspace') }
+
+    describe 'when running workspace_functions action' do
+      let (:cmd_options) { ['--action', 'workspace_functions', '--local-workspace', workspace] }
+
+      it 'should return a deserializable function list with the named fixtures' do
+        result = run_sidecar(cmd_options)
+        deserial = PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionList.new()
+        expect { deserial.from_json!(result) }.to_not raise_error
+
+        expect(deserial).to_not contain_child_with_key(:pup4_env_badfile)
+        expect(deserial).to_not contain_child_with_key(:'badname::pup4_function')
+        expect(deserial).to contain_child_with_key(:env_function)
+        expect(deserial).to contain_child_with_key(:pup4_env_function)
+        expect(deserial).to contain_child_with_key(:pup4_env_badfunction)
+        expect(deserial).to contain_child_with_key(:'profile::pup4_envprofile_function')
+
+        # Make sure the function has the right properties
+        func = child_with_key(deserial, :env_function)
+        expect(func.doc).to eq('doc_env_function')
+        expect(func.source).to match(/valid_environment_workspace/)
+        expect(func.version).to eq(3)
+
+        # Make sure the function has the right properties
+        func = child_with_key(deserial, :pup4_env_function)
+        expect(func.doc).to be_nil  # Currently we can't get the documentation for v4 functions
+        expect(func.source).to match(/valid_environment_workspace/)
+        expect(func.version).to eq(4)
+        expect(func.signatures).to_not be_nil
+      end
+    end
+  end
+end

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/puppet-languageserver-sidecar_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/puppet-languageserver-sidecar_spec.rb
@@ -2,49 +2,49 @@ require 'spec_helper'
 require 'open3'
 require 'tempfile'
 
-def run_sidecar(cmd_options)
-  cmd_options << '--no-cache'
-
-  # Append the puppet test-fixtures
-  cmd_options << '--puppet-settings'
-  cmd_options << "--vardir,#{File.join($fixtures_dir, 'real_agent', 'cache')},--confdir,#{File.join($fixtures_dir, 'real_agent', 'confdir')}"
-
-  cmd = ['ruby', 'puppet-languageserver-sidecar'].concat(cmd_options)
-  stdout, _stderr, status = Open3.capture3(*cmd)
-
-  raise "Expected exit code of 0, but got #{status.exitstatus} #{_stderr}" unless status.exitstatus.zero?
-  return stdout.bytes.pack('U*')
-end
-
-def child_with_key(array, key)
-  idx = array.index { |item| item.key == key }
-  return idx.nil? ? nil : array[idx]
-end
-
-def with_temporary_file(content)
-  tempfile = Tempfile.new("langserver-sidecar")
-  tempfile.open
-
-  tempfile.write(content)
-
-  tempfile.close
-
-  yield tempfile.path
-ensure
-  tempfile.delete if tempfile
-end
-
-RSpec::Matchers.define :contain_child_with_key do |key|
-  match do |actual|
-    !(actual.index { |item| item.key == key }).nil?
-  end
-
-  failure_message do |actual|
-    "expected that #{actual.class.to_s} would contain a child with key #{key}"
-  end
-end
-
 describe 'PuppetLanguageServerSidecar' do
+  def run_sidecar(cmd_options)
+    cmd_options << '--no-cache'
+
+    # Append the puppet test-fixtures
+    cmd_options << '--puppet-settings'
+    cmd_options << "--vardir,#{File.join($fixtures_dir, 'real_agent', 'cache')},--confdir,#{File.join($fixtures_dir, 'real_agent', 'confdir')}"
+
+    cmd = ['ruby', 'puppet-languageserver-sidecar'].concat(cmd_options)
+    stdout, _stderr, status = Open3.capture3(*cmd)
+
+    raise "Expected exit code of 0, but got #{status.exitstatus} #{_stderr}" unless status.exitstatus.zero?
+    return stdout.bytes.pack('U*')
+  end
+
+  def child_with_key(array, key)
+    idx = array.index { |item| item.key == key }
+    return idx.nil? ? nil : array[idx]
+  end
+
+  def with_temporary_file(content)
+    tempfile = Tempfile.new("langserver-sidecar")
+    tempfile.open
+
+    tempfile.write(content)
+
+    tempfile.close
+
+    yield tempfile.path
+  ensure
+    tempfile.delete if tempfile
+  end
+
+  RSpec::Matchers.define :contain_child_with_key do |key|
+    match do |actual|
+      !(actual.index { |item| item.key == key }).nil?
+    end
+
+    failure_message do |actual|
+      "expected that #{actual.class.to_s} would contain a child with key #{key}"
+    end
+  end
+
   describe 'when running default_classes action' do
     let (:cmd_options) { ['--action', 'default_classes'] }
 

--- a/spec/languageserver-sidecar/unit/puppet-languageserver-sidecar/sidecar_protocol_extensions_spec.rb
+++ b/spec/languageserver-sidecar/unit/puppet-languageserver-sidecar/sidecar_protocol_extensions_spec.rb
@@ -69,9 +69,11 @@ describe 'PuppetLanguageServerSidecar::Protocol' do
     let(:puppet_funcname) { :rspec_function }
     let(:puppet_func) {
       {
+        :key             => puppet_funcname,
         :doc             => 'function documentation',
-        :arity           => 0,
         :type            => :statement,
+        :signatures      => ['sig1', 'sig2'],
+        :version         => 3,
         :source_location => {
           :source => 'source',
           :line   => 1,
@@ -85,14 +87,20 @@ describe 'PuppetLanguageServerSidecar::Protocol' do
       it 'should populate from a Puppet function object' do
         result = subject_klass.from_puppet(puppet_funcname, puppet_func)
 
+        expect(result.key).to eq(puppet_func[:key])
+        expect(result.calling_source).to eq(puppet_func[:source_location][:source])
+        expect(result.source).to eq(puppet_func[:source_location][:source])
+        expect(result.line).to eq(puppet_func[:source_location][:line])
+
         expect(result.doc).to eq(puppet_func[:doc])
-        expect(result.arity).to eq(puppet_func[:arity])
         expect(result.type).to eq(puppet_func[:type])
+        expect(result.version).to eq(puppet_func[:version])
+        expect(result.signatures).to eq(puppet_func[:signatures])
       end
     end
 
     describe '#from_json' do
-      [:doc, :arity, :type].each do |testcase|
+      [:doc, :type, :version, :signatures].each do |testcase|
         it "should deserialize a serialized #{testcase} value" do
           serial = subject_klass.from_puppet(puppet_funcname, puppet_func)
           deserial = subject_klass.new.from_json!(serial.to_json)

--- a/spec/languageserver/spec_helper.rb
+++ b/spec/languageserver/spec_helper.rb
@@ -79,8 +79,13 @@ end
 def random_sidecar_puppet_function
   result = add_random_basepuppetobject_values!(PuppetLanguageServer::Sidecar::Protocol::PuppetFunction.new())
   result.doc = 'doc' + rand(1000).to_s
-  result.arity = rand(1000)
   result.type = ('type' + rand(1000).to_s).intern
+  result.version = rand(1000)
+  result.signatures = [
+    "#{result.key}([Object]Param#{rand(1000)},[Object]Param#{rand(1000)})",
+    "#{result.key}([String]Param#{rand(1000)},[Optional]Param#{rand(1000)})",
+    "#{result.key}([Object]Param#{rand(1000)},[Object]Param#{rand(1000)})"
+  ]
   result
 end
 

--- a/spec/languageserver/unit/puppet-languageserver/puppet_helper/cache_objects_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/puppet_helper/cache_objects_spec.rb
@@ -46,7 +46,7 @@ describe 'PuppetLanguageServer::PuppetHelper' do
 
     it_should_behave_like 'a base Puppet object'
 
-    [:doc, :arity, :type].each do |testcase|
+    [:doc, :type, :version, :signatures].each do |testcase|
       it "instance should respond to #{testcase}" do
         expect(subject).to respond_to(testcase)
       end
@@ -63,8 +63,9 @@ describe 'PuppetLanguageServer::PuppetHelper' do
         expect(subject.char).to eq(sidecar_puppet_func.char)
         expect(subject.length).to eq(sidecar_puppet_func.length)
         expect(subject.doc).to eq(sidecar_puppet_func.doc)
-        expect(subject.arity).to eq(sidecar_puppet_func.arity)
         expect(subject.type).to eq(sidecar_puppet_func.type)
+        expect(subject.version).to eq(sidecar_puppet_func.version)
+        expect(subject.signatures).to eq(sidecar_puppet_func.signatures)
       end
     end
   end

--- a/spec/languageserver/unit/puppet-languageserver/sidecar_protocol_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/sidecar_protocol_spec.rb
@@ -55,7 +55,7 @@ describe 'PuppetLanguageServer::Sidecar::Protocol' do
   basepuppetobject_properties = [:key, :calling_source, :source, :line, :char, :length]
   nodegraph_properties = [:dot_content, :error_content]
   puppetclass_properties = [:doc, :parameters]
-  puppetfunction_properties = [:doc, :arity, :type]
+  puppetfunction_properties = [:doc, :type, :version, :signatures]
   puppettype_properties = [:doc, :attributes]
   resource_properties = [:manifest]
 
@@ -190,8 +190,9 @@ describe 'PuppetLanguageServer::Sidecar::Protocol' do
     let(:subject) {
       value = subject_klass.new
       value.doc = 'doc'
-      value.arity = 'arity'
       value.type = :type
+      value.version = 3
+      value.signatures = ['abc', 'def']
       add_default_basepuppetobject_values!(value)
     }
 

--- a/tools/bolt_extraction/Gemfile
+++ b/tools/bolt_extraction/Gemfile
@@ -1,0 +1,28 @@
+source ENV['GEM_SOURCE'] || "https://rubygems.org"
+
+gem "bolt", :require => false
+
+#   when /darwin/
+#     gem 'CFPropertyList'
+#   end
+
+#   gem "win32-dir", "<= 0.4.9",      :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
+#   gem "win32-eventlog", "<= 0.6.5", :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
+#   gem "win32-process", "<= 0.7.5",  :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
+#   gem "win32-security", "<= 0.2.5", :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
+#   gem "win32-service", "<= 0.8.8",  :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
+
+#   # Gems for building release tarballs etc.
+#   gem "archive-zip", :require => false
+#   gem "minitar"    , :require => false
+# end
+
+# Evaluate Gemfile.local if it exists
+if File.exists? "#{__FILE__}.local"
+  eval(File.read("#{__FILE__}.local"), binding)
+end
+
+# Evaluate ~/.gemfile if it exists
+if File.exists?(File.join(Dir.home, '.gemfile'))
+  eval(File.read(File.join(Dir.home, '.gemfile')), binding)
+end

--- a/tools/bolt_extraction/test.rb
+++ b/tools/bolt_extraction/test.rb
@@ -1,0 +1,4 @@
+puts File.expand_path(File.join(File.dirname(__FILE__), '..'))
+
+bolt_module_path = 'C:\\Source\\puppet-editor-services\\tools\\bolt_extraction\\.bundle\\windows\\ruby\\2.4.0\\gems\\bolt-1.10.0\\bolt-modules'
+


### PR DESCRIPTION
WIP

**Functions**
- [ ] Parity with Puppet 3 API functions (Almost, need documentation!)
- [ ] Need to check signature generation as it's a bit weird somtimes
- [ ] Need to create  a new class for PuppetFunctionSignatures
- [ ] Do I need to generate Snippet level text too for the signatures?
- [x] Integration tests

**Puppet Types**
- [ ] Parity with Puppet 3 API functions
- [ ] Unit tests
- [ ] Integration tests
- [ ] Feature flag integration tests

**Puppet Classes/Defined Types**
- [ ] Parity with Puppet 3 API functions
- [ ] Unit tests
- [ ] Integration tests
- [ ] Feature flag integration tests

**General**
- [ ] Need to ticket up additional information that Pup4 API can extract `:plan` `:task` `:resource_type_pp` `:type`
- [x] ~~Need to test on PUppet 5.4.0, 5.5.0, 5.6.0 and 5.7.0.  Make sure that `puppet_pal_supported?` is actually true and correct.~~  Turns out Pup 6.x