### PR TITLE
(maint) Fix typo for UTF8 file output

### DIFF
--- a/lib/puppet_languageserver_sidecar.rb
+++ b/lib/puppet_languageserver_sidecar.rb
@@ -254,7 +254,7 @@ module PuppetLanguageServerSidecar
       STDOUT.binmode
       STDOUT.write(result.to_json)
     else
-      File.open(options[:output], 'wb:UTF8') do |f|
+      File.open(options[:output], 'wb:UTF-8') do |f|
         f.write result.to_json
       end
     end


### PR DESCRIPTION
Fixes a typo when writing a sidecar file.