### PR TITLE
(GH-111) Add --puppet-version command line argument

### DIFF
--- a/lib/puppet-editor-services/logging.rb
+++ b/lib/puppet-editor-services/logging.rb
@@ -8,7 +8,7 @@ module PuppetEditorServices
     when :info
       @logger.info(message)
     when :warn
-      @logger.info(message)
+      @logger.warn(message)
     when :error
       @logger.error(message)
     when :fatal

--- a/lib/puppet-languageserver/sidecar_queue.rb
+++ b/lib/puppet-languageserver/sidecar_queue.rb
@@ -159,7 +159,8 @@ module PuppetLanguageServer
       return [] if @queue_options.nil?
       result = []
       result << '--no-cache' if @queue_options[:disable_sidecar_cache]
-      result << "--feature-flags=#{@queue_options[:flags].join(',')}" if @queue_options[:flags]
+      result << "--puppet-version=#{Puppet.version}"
+      result << "--feature-flags=#{@queue_options[:flags].join(',')}" if @queue_options[:flags] && !@queue_options[:flags].empty?
       result << "--puppet-settings=#{@queue_options[:puppet_settings].join(',')}" if @queue_options[:puppet_settings] && !@queue_options[:puppet_settings].empty?
       result
     end

--- a/lib/puppet_debugserver.rb
+++ b/lib/puppet_debugserver.rb
@@ -1,20 +1,49 @@
 require 'debugserver/debug_protocol'
 require 'puppet_editor_services'
 
-%w[json_handler message_router hooks puppet_debug_session debug_hook_handlers puppet_debug_breakpoints puppet_monkey_patches].each do |lib|
-  begin
-    require "puppet-debugserver/#{lib}"
-  rescue LoadError
-    require File.expand_path(File.join(File.dirname(__FILE__), 'puppet-debugserver', lib))
-  end
-end
-
 require 'optparse'
 require 'logger'
 
 module PuppetDebugServer
   def self.version
     PuppetEditorServices.version
+  end
+
+  def self.require_gems(options)
+    original_verbose = $VERBOSE
+    $VERBOSE = nil
+
+    # Use specific Puppet Gem version if possible
+    # Note that puppet is required implicitly in the monkey patches
+    # so we don't need to explicity require it here
+    unless options[:puppet_version].nil?
+      available_puppet_gems = Gem::Specification
+                              .select { |item| item.name.casecmp('puppet').zero? }
+                              .map { |item| item.version.to_s }
+      if available_puppet_gems.include?(options[:puppet_version])
+        gem 'puppet', options[:puppet_version]
+      else
+        log_message(:warn, "Unable to use puppet version #{options[:puppet_version]}, as only the following versions are available [#{available_puppet_gems.join(', ')}]")
+      end
+    end
+
+    %w[
+      json_handler
+      message_router
+      hooks
+      puppet_debug_session
+      debug_hook_handlers
+      puppet_debug_breakpoints
+      puppet_monkey_patches
+    ].each do |lib|
+      begin
+        require "puppet-debugserver/#{lib}"
+      rescue LoadError
+        require File.expand_path(File.join(File.dirname(__FILE__), 'puppet-debugserver', lib))
+      end
+    end
+  ensure
+    $VERBOSE = original_verbose
   end
 
   class CommandLineParser
@@ -25,7 +54,8 @@ module PuppetDebugServer
         ipaddress: 'localhost',
         stop_on_client_exit: true,
         connection_timeout: 10,
-        debug: nil
+        debug: nil,
+        puppet_version: nil
       }
 
       opt_parser = OptionParser.new do |opts|
@@ -45,6 +75,10 @@ module PuppetDebugServer
 
         opts.on('--debug=DEBUG', "Output debug information.  Either specify a filename or 'STDOUT'.  Default is no debug output") do |debug|
           args[:debug] = debug
+        end
+
+        opts.on('--puppet-version=TEXT', String, 'The version of the Puppet Gem to use (defaults to latest version if not specified or the version does not exist) e.g. --puppet-version=5.4.0') do |text|
+          args[:puppet_version] = text
         end
 
         opts.on('-h', '--help', 'Prints this help') do
@@ -69,7 +103,10 @@ module PuppetDebugServer
 
   def self.init_puppet(options)
     PuppetEditorServices.init_logging(options)
-    log_message(:info, "Debug Server is v#{PuppetEditorServices.version}")
+    log_message(:info, "Debug Server is v#{PuppetDebugServer.version}")
+    log_message(:debug, 'Loading gems...')
+    require_gems(options)
+    log_message(:info, "Using Puppet v#{::Puppet.version}")
 
     true
   end


### PR DESCRIPTION
Previously it was not possible to specify which puppet gem version to use via
the command line arguments.  This commit adds a --puppet-version argument to the
language server and also the sidecar.  This commit also passes through the
puppet version from the lanugage server to the sidecar

- [x] add `--puppet-version` to language server
- [x] add `--puppet-version` to language server sidecar
- [x] add `--puppet-version` to debug server
- [x] send message to language client if the server version is mismatched.