### PR TITLE
(GH-113) Rescue errors when running Facter 2.x

### DIFF
--- a/lib/puppet-languageserver/facter_helper.rb
+++ b/lib/puppet-languageserver/facter_helper.rb
@@ -44,8 +44,15 @@ module PuppetLanguageServer
 
     def self._load_facts
       _reset
-      Facter.loadfacts
-      @fact_hash = Facter.to_hash
+      @fact_hash = {}
+      begin
+        Facter.loadfacts
+        @fact_hash = Facter.to_hash
+      rescue StandardError => ex
+        PuppetLanguageServer.log_message(:error, "[FacterHelper::_load_facts] Error loading facts #{ex.message} #{ex.backtrace}")
+      rescue LoadError => ex
+        PuppetLanguageServer.log_message(:error, "[FacterHelper::_load_facts] Error loading facts (LoadError) #{ex.message} #{ex.backtrace}")
+      end
       PuppetLanguageServer.log_message(:debug, "[FacterHelper::_load_facts] Finished loading #{@fact_hash.keys.count} facts")
       @facts_loaded = true
     end


### PR DESCRIPTION
Relates to #113 

Previously the facter helper had no error trapping.  Normally this isn't an
issue on Facter 3.x (Puppet Agent), however the PDK uses Facter 2.x which is
still running in the same ruby session as the Language Server.  This means that
if an error occurs then it could crash the entire language server.  This commit
wraps the facter loading in a rescue block and returns zero facts for
intellisense.
