### PR TITLE
{WIP} (GH-121) Load Puppet Functions via Puppet API and Puppet Strings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,10 @@ group :development do
   else
     gem 'puppet',                            :require => false
   end
+  # TODO Should this be vendored into Editor Services?
+  # The puppet-strings gem is not available in the Puppet Agent, but is in the PDK. We add it to the
+  # Gemfile here for testing and development.
+  gem "puppet-strings", "~> 2.0", :require => false
 
   case RUBY_PLATFORM
   when /darwin/

--- a/Gemfile
+++ b/Gemfile
@@ -18,10 +18,14 @@ group :development do
     gem "rubocop", ">= 0.60.0", :require => false, :platforms => [:ruby, :x64_mingw]
   end
 
-  if ENV['PUPPET_GEM_VERSION']
-    gem 'puppet', ENV['PUPPET_GEM_VERSION'], :require => false
+  if ENV['USERDOMAIN'] == 'GLENNS'
+    gem 'puppet', :path => 'C:\\Source\\puppet',                           :require => false
   else
-    gem 'puppet',                            :require => false
+    if ENV['PUPPET_GEM_VERSION']
+      gem 'puppet', ENV['PUPPET_GEM_VERSION'], :require => false
+    else
+      gem 'puppet',                            :require => false
+    end
   end
   # TODO Should this be vendored into Editor Services?
   # The puppet-strings gem is not available in the Puppet Agent, but is in the PDK. We add it to the

--- a/lib/puppet-languageserver-sidecar/puppet_helper_puppetstrings.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_helper_puppetstrings.rb
@@ -1,0 +1,359 @@
+# frozen_string_literal: true
+
+require 'puppet/indirector/face'
+
+module PuppetLanguageServerSidecar
+  module PuppetHelper
+    SIDECAR_PUPPET_ENVIRONMENT = 'sidecarenvironment'
+
+    def self.path_has_child?(path, child)
+      # Doesn't matter what the child is, if the path is nil it's true.
+      return true if path.nil?
+      return false if path.length >= child.length
+
+      value = child.slice(0, path.length)
+      return true if value.casecmp(path).zero?
+      false
+    end
+
+    # Resource Face
+    def self.get_puppet_resource(typename, title = nil)
+      result = PuppetLanguageServer::Sidecar::Protocol::PuppetClassList.new
+      if title.nil?
+        resources = Puppet::Face[:resource, '0.0.1'].search(typename)
+      else
+        resources = Puppet::Face[:resource, '0.0.1'].find("#{typename}/#{title}")
+      end
+      return result if resources.nil?
+      resources = [resources] unless resources.is_a?(Array)
+      prune_resource_parameters(resources).each do |item|
+        obj = PuppetLanguageServer::Sidecar::Protocol::Resource.new
+        obj.manifest = item.to_manifest
+        result << obj
+      end
+      result
+    end
+
+    # Class and Defined Type loading
+    def self.retrieve_classes(cache, options = {})
+      PuppetLanguageServerSidecar.log_message(:debug, '[PuppetHelper::retrieve_classes] Starting')
+
+      # TODO: Can probably do this better, but this works.
+      current_env = current_environment
+      module_path_list = current_env
+                         .modules
+                         .select { |mod| Dir.exist?(File.join(mod.path, 'manifests')) }
+                         .map { |mod| mod.path }
+      manifest_path_list = module_path_list.map { |mod_path| File.join(mod_path, 'manifests') }
+      PuppetLanguageServerSidecar.log_message(:debug, "[PuppetHelper::retrieve_classes] Loading classes from #{module_path_list}")
+
+      # Find and parse all manifests in the manifest paths
+      classes = PuppetLanguageServer::Sidecar::Protocol::PuppetClassList.new
+      manifest_path_list.each do |manifest_path|
+        Dir.glob("#{manifest_path}/**/*.pp").each do |manifest_file|
+          begin
+            if path_has_child?(options[:root_path], manifest_file) # rubocop:disable Style/IfUnlessModifier  Nicer to read like this
+              classes.concat(load_classes_from_manifest(cache, manifest_file))
+            end
+          rescue StandardError => e
+            PuppetLanguageServerSidecar.log_message(:error, "[PuppetHelper::retrieve_classes] Error loading manifest #{manifest_file}: #{e} #{e.backtrace}")
+          end
+        end
+      end
+
+      PuppetLanguageServerSidecar.log_message(:debug, "[PuppetHelper::retrieve_classes] Finished loading #{classes.count} classes")
+      classes
+    end
+
+    # Function loading
+    def self.retrieve_functions(cache, options = {})
+      PuppetLanguageServerSidecar.log_message(:debug, '[PuppetHelper::load_functions] Starting')
+
+      autoloader = Puppet::Util::Autoload.new(self, 'puppet/parser/functions')
+      current_env = current_environment
+      funcs = PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionList.new
+
+      # Functions that are already loaded (e.g. system default functions like alert)
+      # should already be populated so insert them into the function results
+      #
+      # Find the unique filename list
+      filenames = []
+      Puppet::Parser::Functions.monkey_function_list.each_value do |data|
+        filenames << data[:source_location][:source] unless data[:source_location].nil? || data[:source_location][:source].nil?
+      end
+      # Now add the functions in each file to the cache
+      filenames.uniq.compact.each do |filename|
+        Puppet::Parser::Functions.monkey_function_list
+                                 .select { |_k, i| filename.casecmp(i[:source_location][:source].to_s).zero? }
+                                 .select { |_k, i| path_has_child?(options[:root_path], i[:source_location][:source]) }
+                                 .each do |name, item|
+          obj = PuppetLanguageServerSidecar::Protocol::PuppetFunction.from_puppet(name, item)
+          funcs << obj
+        end
+      end
+
+      # Now we can load functions from the default locations
+      if autoloader.method(:files_to_load).arity.zero?
+        params = []
+      else
+        params = [current_env]
+      end
+      autoloader.files_to_load(*params).each do |file|
+        name = file.gsub(autoloader.path + '/', '')
+        begin
+          expanded_name = autoloader.expand(name)
+          absolute_name = Puppet::Util::Autoload.get_file(expanded_name, current_env)
+          raise("Could not find absolute path of function #{name}") if absolute_name.nil?
+          if path_has_child?(options[:root_path], absolute_name) # rubocop:disable Style/IfUnlessModifier  Nicer to read like this
+            funcs.concat(load_function_file(cache, name, absolute_name, autoloader, current_env))
+          end
+        rescue StandardError => e
+          PuppetLanguageServerSidecar.log_message(:error, "[PuppetHelper::load_functions] Error loading function #{file}: #{e} #{e.backtrace}")
+        end
+      end
+
+      PuppetLanguageServerSidecar.log_message(:debug, "[PuppetHelper::load_functions] Finished loading #{funcs.count} functions")
+      funcs
+    end
+
+    def self.retrieve_types(cache, options = {})
+      PuppetLanguageServerSidecar.log_message(:debug, '[PuppetHelper::retrieve_types] Starting')
+
+      # From https://github.com/puppetlabs/puppet/blob/ebd96213cab43bb2a8071b7ac0206c3ed0be8e58/lib/puppet/metatype/manager.rb#L182-L189
+      autoloader = Puppet::Util::Autoload.new(self, 'puppet/type')
+      current_env = current_environment
+      types = PuppetLanguageServer::Sidecar::Protocol::PuppetTypeList.new
+
+      # This is an expensive call
+      if autoloader.method(:files_to_load).arity.zero?
+        params = []
+      else
+        params = [current_env]
+      end
+      autoloader.files_to_load(*params).each do |file|
+        name = file.gsub(autoloader.path + '/', '')
+        begin
+          expanded_name = autoloader.expand(name)
+          absolute_name = Puppet::Util::Autoload.get_file(expanded_name, current_env)
+          raise("Could not find absolute path of type #{name}") if absolute_name.nil?
+          if path_has_child?(options[:root_path], absolute_name) # rubocop:disable Style/IfUnlessModifier  Nicer to read like this
+            types.concat(load_type_file(cache, name, absolute_name, autoloader, current_env))
+          end
+        rescue StandardError => e
+          PuppetLanguageServerSidecar.log_message(:error, "[PuppetHelper::retrieve_types] Error loading type #{file}: #{e} #{e.backtrace}")
+        end
+      end
+
+      PuppetLanguageServerSidecar.log_message(:debug, "[PuppetHelper::retrieve_types] Finished loading #{types.count} type/s")
+
+      types
+    end
+
+    # Private functions
+
+    def self.prune_resource_parameters(resources)
+      # From https://github.com/puppetlabs/puppet/blob/488661d84e54904124514ab9e4500e81b10f84d1/lib/puppet/application/resource.rb#L146-L148
+      if resources.is_a?(Array)
+        resources.map(&:prune_parameters)
+      else
+        resources.prune_parameters
+      end
+    end
+    private_class_method :prune_resource_parameters
+
+    def self.current_environment
+      begin
+        env = Puppet.lookup(:environments).get!(Puppet.settings[:environment])
+        return env unless env.nil?
+      rescue Puppet::Environments::EnvironmentNotFound
+        PuppetLanguageServerSidecar.log_message(:warning, "[PuppetHelper::current_environment] Unable to load environment #{Puppet.settings[:environment]}")
+      rescue StandardError => e
+        PuppetLanguageServerSidecar.log_message(:warning, "[PuppetHelper::current_environment] Error loading environment #{Puppet.settings[:environment]}: #{e}")
+      end
+      Puppet.lookup(:current_environment)
+    end
+    private_class_method :current_environment
+
+    def self.load_classes_from_manifest(cache, manifest_file)
+      class_info = PuppetLanguageServer::Sidecar::Protocol::PuppetClassList.new
+
+      if cache.active?
+        cached_result = cache.load(manifest_file, PuppetLanguageServerSidecar::Cache::CLASSES_SECTION)
+        unless cached_result.nil?
+          begin
+            class_info.from_json!(cached_result)
+            return class_info
+          rescue StandardError => e
+            PuppetLanguageServerSidecar.log_message(:warn, "[PuppetHelper::load_classes_from_manifest] Error while deserializing #{manifest_file} from cache: #{e}")
+            class_info = PuppetLanguageServer::Sidecar::Protocol::PuppetClassList.new
+          end
+        end
+      end
+
+      file_content = File.open(manifest_file, 'r:UTF-8') { |f| f.read }
+
+      parser = Puppet::Pops::Parser::Parser.new
+      result = nil
+      begin
+        result = parser.parse_string(file_content, '')
+      rescue Puppet::ParseErrorWithIssue
+        # Any parsing errors means we can't inspect the document
+        return class_info
+      end
+
+      # Enumerate the entire AST looking for classes and defined types
+      # TODO: Need to learn how to read the help/docs for hover support
+      if result.model.respond_to? :eAllContents
+        # Puppet 4 AST
+        result.model.eAllContents.select do |item|
+          puppet_class = {}
+          case item.class.to_s
+          when 'Puppet::Pops::Model::HostClassDefinition'
+            puppet_class['type'] = :class
+          when 'Puppet::Pops::Model::ResourceTypeDefinition'
+            puppet_class['type'] = :typedefinition
+          else
+            next
+          end
+          puppet_class['name']       = item.name
+          puppet_class['doc']        = nil
+          puppet_class['parameters'] = item.parameters
+          puppet_class['source']     = manifest_file
+          puppet_class['line']       = result.locator.line_for_offset(item.offset) - 1
+          puppet_class['char']       = result.locator.offset_on_line(item.offset)
+
+          obj = PuppetLanguageServerSidecar::Protocol::PuppetClass.from_puppet(item.name, puppet_class, result.locator)
+          class_info << obj
+        end
+      else
+        result.model._pcore_all_contents([]) do |item|
+          puppet_class = {}
+          case item.class.to_s
+          when 'Puppet::Pops::Model::HostClassDefinition'
+            puppet_class['type'] = :class
+          when 'Puppet::Pops::Model::ResourceTypeDefinition'
+            puppet_class['type'] = :typedefinition
+          else
+            next
+          end
+          puppet_class['name']       = item.name
+          puppet_class['doc']        = nil
+          puppet_class['parameters'] = item.parameters
+          puppet_class['source']     = manifest_file
+          puppet_class['line']       = item.line
+          puppet_class['char']       = item.pos
+          obj = PuppetLanguageServerSidecar::Protocol::PuppetClass.from_puppet(item.name, puppet_class, item.locator)
+          class_info << obj
+        end
+      end
+      cache.save(manifest_file, PuppetLanguageServerSidecar::Cache::CLASSES_SECTION, class_info.to_json) if cache.active?
+
+      class_info
+    end
+    private_class_method :load_classes_from_manifest
+
+    def self.load_function_file(cache, name, absolute_name, autoloader, env)
+      funcs = PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionList.new
+
+      if cache.active?
+        cached_result = cache.load(absolute_name, PuppetLanguageServerSidecar::Cache::FUNCTIONS_SECTION)
+        unless cached_result.nil?
+          begin
+            funcs.from_json!(cached_result)
+            return funcs
+          rescue StandardError => e
+            PuppetLanguageServerSidecar.log_message(:warn, "[PuppetHelper::load_function_file] Error while deserializing #{absolute_name} from cache: #{e}")
+            funcs = PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionList.new
+          end
+        end
+      end
+
+      unless autoloader.loaded?(name)
+        # This is an expensive call
+        unless autoloader.load(name, env) # rubocop:disable Style/IfUnlessModifier  Nicer to read like this
+          PuppetLanguageServerSidecar.log_message(:error, "[PuppetHelper::load_function_file] function #{absolute_name} did not load")
+        end
+      end
+
+      # Find the functions that were loaded based on source file name (case insensitive)
+      Puppet::Parser::Functions.monkey_function_list
+                               .select { |_k, i| absolute_name.casecmp(i[:source_location][:source].to_s).zero? }
+                               .each do |func_name, item|
+        obj = PuppetLanguageServerSidecar::Protocol::PuppetFunction.from_puppet(func_name, item)
+        obj.calling_source = absolute_name
+        funcs << obj
+      end
+      PuppetLanguageServerSidecar.log_message(:warn, "[PuppetHelper::load_function_file] file #{absolute_name} did load any functions") if funcs.count.zero?
+      cache.save(absolute_name, PuppetLanguageServerSidecar::Cache::FUNCTIONS_SECTION, funcs.to_json) if cache.active?
+
+      funcs
+    end
+    private_class_method :load_function_file
+
+    def self.load_type_file(cache, name, absolute_name, autoloader, env)
+      types = PuppetLanguageServer::Sidecar::Protocol::PuppetTypeList.new
+      if cache.active?
+        cached_result = cache.load(absolute_name, PuppetLanguageServerSidecar::Cache::TYPES_SECTION)
+        unless cached_result.nil?
+          begin
+            types.from_json!(cached_result)
+            return types
+          rescue StandardError => e
+            PuppetLanguageServerSidecar.log_message(:warn, "[PuppetHelper::load_type_file] Error while deserializing #{absolute_name} from cache: #{e}")
+            types = PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionList.new
+          end
+        end
+      end
+
+      # Get the list of currently loaded types
+      loaded_types = []
+      # Due to PUP-8301, if no types have been loaded yet then Puppet::Type.eachtype
+      # will throw instead of not yielding.
+      begin
+        Puppet::Type.eachtype { |item| loaded_types << item.name }
+      rescue NoMethodError => e
+        # Detect PUP-8301
+        if e.respond_to?(:receiver)
+          raise unless e.name == :each && e.receiver.nil?
+        else
+          raise unless e.name == :each && e.message =~ /nil:NilClass/
+        end
+      end
+
+      unless autoloader.loaded?(name)
+        # This is an expensive call
+        unless autoloader.load(name, env) # rubocop:disable Style/IfUnlessModifier  Nicer to read like this
+          PuppetLanguageServerSidecar.log_message(:error, "[PuppetHelper::load_type_file] type #{absolute_name} did not load")
+        end
+      end
+
+      # Find the types that were loaded
+      # Due to PUP-8301, if no types have been loaded yet then Puppet::Type.eachtype
+      # will throw instead of not yielding.
+      begin
+        Puppet::Type.eachtype do |item|
+          next if loaded_types.include?(item.name)
+          # Ignore the internal only Puppet Types
+          next if item.name == :component || item.name == :whit
+          obj = PuppetLanguageServerSidecar::Protocol::PuppetType.from_puppet(item.name, item)
+          # TODO: Need to use calling_source in the cache backing store
+          # Perhaps I should be incrementally adding items to the cache instead of batch mode?
+          obj.calling_source = absolute_name
+          types << obj
+        end
+      rescue NoMethodError => e
+        # Detect PUP-8301
+        if e.respond_to?(:receiver)
+          raise unless e.name == :each && e.receiver.nil?
+        else
+          raise unless e.name == :each && e.message =~ /nil:NilClass/
+        end
+      end
+      PuppetLanguageServerSidecar.log_message(:warn, "[PuppetHelper::load_type_file] type #{absolute_name} did not load any types") if types.empty?
+      cache.save(absolute_name, PuppetLanguageServerSidecar::Cache::TYPES_SECTION, types.to_json) if cache.active?
+
+      types
+    end
+    private_class_method :load_type_file
+  end
+end

--- a/lib/puppet-languageserver-sidecar/puppet_helper_puppetstrings.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_helper_puppetstrings.rb
@@ -34,6 +34,53 @@ module PuppetLanguageServerSidecar
       result
     end
 
+    # Puppet Strings loading
+    def self.available_documentation_types
+      [:function]
+    end
+
+    # Retrieve objects via the Puppet 4 API loaders
+    def self.retrieve_via_puppet_strings(_cache, options = {})
+      PuppetLanguageServerSidecar.log_message(:debug, '[PuppetHelper::retrieve_via_pup4_api] Starting')
+
+      object_types = options[:object_types].nil? ? available_documentation_types : options[:object_types]
+      object_types.select! { |i| available_documentation_types.include?(i) }
+
+      result = {}
+      return result if object_types.empty?
+
+      result[:functions] = PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionList.new if object_types.include?(:function)
+
+      current_env = current_environment
+      for_agent = options[:for_agent].nil? ? true : options[:for_agent]
+      loaders = Puppet::Pops::Loaders.new(current_env, for_agent)
+
+      paths = []
+      paths.concat(discover_type_paths(:function, loaders)) if object_types.include?(:function)
+
+      paths.each do |path|
+        next unless path_has_child?(options[:root_path], path)
+        file_doc = PuppetLanguageServerSidecar::PuppetStringsHelper.file_documentation(path)
+        next if file_doc.nil?
+
+        if object_types.include?(:function) # rubocop:disable Style/IfUnlessModifier   This reads better
+          file_doc.functions.each { |_name, item| result[:functions] << item }
+        end
+      end
+
+      # Remove Puppet3 functions which have a Puppet4 function already loaded
+      if object_types.include?(:function)
+        pup4_functions = result[:functions].select { |i| i.function_version == 4 }.map { |i| i.key }
+        result[:functions].reject! { |i| i.function_version == 3 && pup4_functions.include?(i.key) }
+      end
+
+      result
+    end
+
+    def self.discover_type_paths(type, loaders)
+      loaders.private_environment_loader.discover_paths(type)
+    end
+
     # Class and Defined Type loading
     def self.retrieve_classes(cache, options = {})
       PuppetLanguageServerSidecar.log_message(:debug, '[PuppetHelper::retrieve_classes] Starting')
@@ -63,57 +110,6 @@ module PuppetLanguageServerSidecar
 
       PuppetLanguageServerSidecar.log_message(:debug, "[PuppetHelper::retrieve_classes] Finished loading #{classes.count} classes")
       classes
-    end
-
-    # Function loading
-    def self.retrieve_functions(cache, options = {})
-      PuppetLanguageServerSidecar.log_message(:debug, '[PuppetHelper::load_functions] Starting')
-
-      autoloader = Puppet::Util::Autoload.new(self, 'puppet/parser/functions')
-      current_env = current_environment
-      funcs = PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionList.new
-
-      # Functions that are already loaded (e.g. system default functions like alert)
-      # should already be populated so insert them into the function results
-      #
-      # Find the unique filename list
-      filenames = []
-      Puppet::Parser::Functions.monkey_function_list.each_value do |data|
-        filenames << data[:source_location][:source] unless data[:source_location].nil? || data[:source_location][:source].nil?
-      end
-      # Now add the functions in each file to the cache
-      filenames.uniq.compact.each do |filename|
-        Puppet::Parser::Functions.monkey_function_list
-                                 .select { |_k, i| filename.casecmp(i[:source_location][:source].to_s).zero? }
-                                 .select { |_k, i| path_has_child?(options[:root_path], i[:source_location][:source]) }
-                                 .each do |name, item|
-          obj = PuppetLanguageServerSidecar::Protocol::PuppetFunction.from_puppet(name, item)
-          funcs << obj
-        end
-      end
-
-      # Now we can load functions from the default locations
-      if autoloader.method(:files_to_load).arity.zero?
-        params = []
-      else
-        params = [current_env]
-      end
-      autoloader.files_to_load(*params).each do |file|
-        name = file.gsub(autoloader.path + '/', '')
-        begin
-          expanded_name = autoloader.expand(name)
-          absolute_name = Puppet::Util::Autoload.get_file(expanded_name, current_env)
-          raise("Could not find absolute path of function #{name}") if absolute_name.nil?
-          if path_has_child?(options[:root_path], absolute_name) # rubocop:disable Style/IfUnlessModifier  Nicer to read like this
-            funcs.concat(load_function_file(cache, name, absolute_name, autoloader, current_env))
-          end
-        rescue StandardError => e
-          PuppetLanguageServerSidecar.log_message(:error, "[PuppetHelper::load_functions] Error loading function #{file}: #{e} #{e.backtrace}")
-        end
-      end
-
-      PuppetLanguageServerSidecar.log_message(:debug, "[PuppetHelper::load_functions] Finished loading #{funcs.count} functions")
-      funcs
     end
 
     def self.retrieve_types(cache, options = {})
@@ -251,44 +247,6 @@ module PuppetLanguageServerSidecar
       class_info
     end
     private_class_method :load_classes_from_manifest
-
-    def self.load_function_file(cache, name, absolute_name, autoloader, env)
-      funcs = PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionList.new
-
-      if cache.active?
-        cached_result = cache.load(absolute_name, PuppetLanguageServerSidecar::Cache::FUNCTIONS_SECTION)
-        unless cached_result.nil?
-          begin
-            funcs.from_json!(cached_result)
-            return funcs
-          rescue StandardError => e
-            PuppetLanguageServerSidecar.log_message(:warn, "[PuppetHelper::load_function_file] Error while deserializing #{absolute_name} from cache: #{e}")
-            funcs = PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionList.new
-          end
-        end
-      end
-
-      unless autoloader.loaded?(name)
-        # This is an expensive call
-        unless autoloader.load(name, env) # rubocop:disable Style/IfUnlessModifier  Nicer to read like this
-          PuppetLanguageServerSidecar.log_message(:error, "[PuppetHelper::load_function_file] function #{absolute_name} did not load")
-        end
-      end
-
-      # Find the functions that were loaded based on source file name (case insensitive)
-      Puppet::Parser::Functions.monkey_function_list
-                               .select { |_k, i| absolute_name.casecmp(i[:source_location][:source].to_s).zero? }
-                               .each do |func_name, item|
-        obj = PuppetLanguageServerSidecar::Protocol::PuppetFunction.from_puppet(func_name, item)
-        obj.calling_source = absolute_name
-        funcs << obj
-      end
-      PuppetLanguageServerSidecar.log_message(:warn, "[PuppetHelper::load_function_file] file #{absolute_name} did load any functions") if funcs.count.zero?
-      cache.save(absolute_name, PuppetLanguageServerSidecar::Cache::FUNCTIONS_SECTION, funcs.to_json) if cache.active?
-
-      funcs
-    end
-    private_class_method :load_function_file
 
     def self.load_type_file(cache, name, absolute_name, autoloader, env)
       types = PuppetLanguageServer::Sidecar::Protocol::PuppetTypeList.new

--- a/lib/puppet-languageserver-sidecar/puppet_monkey_patches_puppetstrings.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_monkey_patches_puppetstrings.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+# Monkey Patch 3.x functions so where know where they were loaded from
+require 'puppet/parser/functions'
+module Puppet
+  module Parser
+    module Functions
+      class << self
+        alias_method :original_newfunction, :newfunction
+        def newfunction(name, options = {}, &block)
+          # See if we've hooked elsewhere. This can happen while in debuggers (pry). If we're not in the previous caller
+          # stack then just use the last caller
+          monkey_index = Kernel.caller_locations.find_index { |loc| loc.path.match(/puppet_monkey_patches\.rb/) }
+          monkey_index = -1 if monkey_index.nil?
+          caller = Kernel.caller_locations[monkey_index + 1]
+          # Call the original new function method
+          result = original_newfunction(name, options, &block)
+          # Append the caller information
+          result[:source_location] = {
+            :source => caller.absolute_path,
+            :line   => caller.lineno - 1 # Convert to a zero based line number system
+          }
+          monkey_append_function_info(name, result)
+
+          result
+        end
+
+        def monkey_clear_function_info
+          @monkey_function_list = {}
+        end
+
+        def monkey_append_function_info(name, value)
+          @monkey_function_list = {} if @monkey_function_list.nil?
+          @monkey_function_list[name] = {
+            :arity           => value[:arity],
+            :name            => value[:name],
+            :type            => value[:type],
+            :doc             => value[:doc],
+            :source_location => value[:source_location]
+          }
+        end
+
+        def monkey_function_list
+          @monkey_function_list = {} if @monkey_function_list.nil?
+          @monkey_function_list.clone
+        end
+      end
+    end
+  end
+end
+
+# Add an additional method on Puppet Types to store their source location
+require 'puppet/type'
+module Puppet
+  class Type
+    class << self
+      attr_accessor :_source_location
+    end
+  end
+end
+
+# Monkey Patch type loading so we can inject the source location information
+require 'puppet/metatype/manager'
+module Puppet
+  module MetaType
+    module Manager
+      alias_method :original_newtype, :newtype
+      def newtype(name, options = {}, &block)
+        result = original_newtype(name, options, &block)
+
+        if block_given? && !block.source_location.nil?
+          result._source_location = {
+            :source => block.source_location[0],
+            :line   => block.source_location[1] - 1 # Convert to a zero based line number system
+          }
+        end
+        result
+      end
+    end
+  end
+end
+
+# MUST BE LAST!!!!!!
+# Suppress any warning messages to STDOUT.  It can pollute stdout when running in STDIO mode
+Puppet::Util::Log.newdesttype :null_logger do
+  def handle(msg)
+    PuppetLanguageServerSidecar.log_message(:debug, "[PUPPET LOG] [#{msg.level}] #{msg.message}")
+  end
+end

--- a/lib/puppet-languageserver-sidecar/puppet_monkey_patches_puppetstrings.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_monkey_patches_puppetstrings.rb
@@ -147,6 +147,12 @@ module Puppet
             end
           end
 
+          if type == :sidecar_manifest
+            current_environment.modules.each do |mod|
+              result.concat(mod.all_manifests)
+            end
+          end
+
           result.concat(super)
           result.uniq
         end

--- a/lib/puppet-languageserver-sidecar/puppet_monkey_patches_puppetstrings.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_monkey_patches_puppetstrings.rb
@@ -118,6 +118,57 @@ module Puppet
   end
 end
 
+# While this is not a monkey patch, but a new class, this class is used purely to
+# enumerate the paths of puppet "things" that aren't already covered as part of the
+# usual loaders. It is implemented as a null loader as it can't actually _load_
+# anything.
+module Puppet
+  module Pops
+    module Loader
+      class PathDiscoveryNullLoader < Puppet::Pops::Loader::NullLoader
+        def discover_paths(type, name_authority = Pcore::RUNTIME_NAME_AUTHORITY)
+          result = []
+
+          if type == :type
+            autoloader = Puppet::Util::Autoload.new(self, 'puppet/type')
+            current_env = current_environment
+
+            # This is an expensive call
+            if autoloader.method(:files_to_load).arity.zero?
+              params = []
+            else
+              params = [current_env]
+            end
+            autoloader.files_to_load(*params).each do |file|
+              name = file.gsub(autoloader.path + '/', '')
+              expanded_name = autoloader.expand(name)
+              absolute_name = Puppet::Util::Autoload.get_file(expanded_name, current_env)
+              result << absolute_name unless absolute_name.nil?
+            end
+          end
+
+          result.concat(super)
+          result.uniq
+        end
+
+        private
+
+        def current_environment
+          begin
+            env = Puppet.lookup(:environments).get!(Puppet.settings[:environment])
+            return env unless env.nil?
+          rescue Puppet::Environments::EnvironmentNotFound
+            PuppetLanguageServerSidecar.log_message(:warning, "[Puppet::Pops::Loader::PathDiscoveryNullLoader::current_environment] Unable to load environment #{Puppet.settings[:environment]}")
+          rescue StandardError => e
+            PuppetLanguageServerSidecar.log_message(:warning, "[Puppet::Pops::Loader::PathDiscoveryNullLoader::current_environment] Error loading environment #{Puppet.settings[:environment]}: #{e}")
+          end
+          Puppet.lookup(:current_environment)
+        end
+      end
+    end
+  end
+end
+
 module Puppet
   module Pops
     module Loader

--- a/lib/puppet-languageserver-sidecar/puppet_monkey_patches_puppetstrings.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_monkey_patches_puppetstrings.rb
@@ -80,6 +80,83 @@ module Puppet
   end
 end
 
+if Gem::Version.new(Puppet.version) >= Gem::Version.new('6.0.0')
+  # Due to PUP-9509, need to monkey patch the cache loader
+  # This need to be guarded on Puppet 6.0.0+
+  require 'puppet/pops/loader/module_loaders'
+  module Puppet
+    module Pops
+      module Loader
+        module ModuleLoaders
+          def self.cached_loader_from(parent_loader, loaders)
+            LibRootedFileBased.new(parent_loader,
+                                   loaders,
+                                   NAMESPACE_WILDCARD,
+                                   Puppet[:libdir],
+                                   'cached_puppet_lib',
+                                   %i[func_4x func_3x datatype])
+          end
+        end
+      end
+    end
+  end
+end
+
+module Puppet
+  module Pops
+    module Loader
+      class Loader
+        def discover_paths(type, name_authority = Pcore::RUNTIME_NAME_AUTHORITY)
+          if parent.nil?
+            []
+          else
+            parent.discover_paths(type, name_authority)
+          end
+        end
+      end
+    end
+  end
+end
+
+module Puppet
+  module Pops
+    module Loader
+      class DependencyLoader
+        def discover_paths(type, name_authority = Pcore::RUNTIME_NAME_AUTHORITY)
+          result = []
+
+          @dependency_loaders.each { |loader| result.concat(loader.discover_paths(type, name_authority)) }
+          result.concat(super)
+          result.uniq
+        end
+      end
+    end
+  end
+end
+
+module Puppet
+  module Pops
+    module Loader
+      module ModuleLoaders
+        class AbstractPathBasedModuleLoader
+          def discover_paths(type, name_authority = Pcore::RUNTIME_NAME_AUTHORITY)
+            result = []
+            if name_authority == Pcore::RUNTIME_NAME_AUTHORITY
+              smart_paths.effective_paths(type).each do |sp|
+                relative_paths(sp).each do |rp|
+                  result << File.join(sp.generic_path, rp)
+                end
+              end
+            end
+            result.concat(super)
+            result.uniq
+          end
+        end
+      end
+    end
+  end
+end
+
 # MUST BE LAST!!!!!!
 # Suppress any warning messages to STDOUT.  It can pollute stdout when running in STDIO mode
 Puppet::Util::Log.newdesttype :null_logger do

--- a/lib/puppet-languageserver-sidecar/puppet_strings_helper.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_strings_helper.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module PuppetLanguageServerSidecar
+  module PuppetStringsHelper
+    # Returns a FileDocumentation object for a given path
+    #
+    # @param [String] path The absolute path to the file that will be documented
+    # @return [FileDocumentation, nil] Returns the documentation for the path, or nil if it cannot be extracted
+    def self.file_documentation(path)
+      return nil unless require_puppet_strings
+      @helper_cache = FileDocumentationCache.new if @helper_cache.nil?
+      return @helper_cache.document(path) if @helper_cache.path_exists?(path)
+      PuppetLanguageServerSidecar.log_message(:debug, "[PuppetStringsHelper::file_documentation] Fetching documentation for #{path}")
+
+      setup_yard!
+
+      # For now, assume a single file path
+      search_patterns = [path]
+
+      # Format the arguments to YARD
+      args = ['doc']
+      args << '--no-output'
+      args << '--quiet'
+      args << '--no-stats'
+      args << '--no-progress'
+      args << '--no-save'
+      args << '--api public'
+      args << '--api private'
+      args << '--no-api'
+      args += search_patterns
+
+      # Run YARD
+      ::YARD::CLI::Yardoc.run(*args)
+
+      # Populate the documentation cache from the YARD information
+      @helper_cache.populate_from_yard_registry!
+
+      # Return the documentation details
+      @helper_cache.document(path)
+    end
+
+    def self.require_puppet_strings
+      return @puppet_strings_loaded unless @puppet_strings_loaded.nil?
+      begin
+        require 'puppet-strings'
+        require 'puppet-strings/yard'
+        require 'puppet-strings/json'
+        @puppet_strings_loaded = true
+      rescue LoadError => e
+        PuppetLanguageServerSidecar.log_message(:error, "[PuppetStringsHelper::require_puppet_strings] Unable to load puppet-strings gem: #{e}")
+        @puppet_strings_loaded = false
+      end
+      @puppet_strings_loaded
+    end
+    private_class_method :require_puppet_strings
+
+    def self.setup_yard!
+      unless @yard_setup # rubocop:disable Style/GuardClause
+        ::PuppetStrings::Yard.setup!
+        @yard_setup = true
+      end
+    end
+    private_class_method :setup_yard!
+  end
+
+  class FileDocumentationCache
+    def initialize
+      # Hash of <[String] path, FileDocumentation> objects
+      @cache = {}
+    end
+
+    def path_exists?(path)
+      @cache.key?(path)
+    end
+
+    def document(path)
+      @cache[path]
+    end
+
+    def populate_from_yard_registry!
+      # Extract all of the information
+      # Ref - https://github.com/puppetlabs/puppet-strings/blob/87a8e10f45bfeb7b6b8e766324bfb126de59f791/lib/puppet-strings/json.rb#L10-L16
+    end
+
+    private
+
+  class FileDocumentation
+    # The path to file that has been documented
+    attr_reader :path
+
+    def initialize(path)
+      @path = path
+    end
+  end
+end

--- a/lib/puppet-languageserver-sidecar/puppet_strings_monkey_patches.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_strings_monkey_patches.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'yard/logging'
+module YARD
+  class Logger < ::Logger
+    # Suppress ANY output
+    def self.instance(_pipe = STDOUT)
+      @logger ||= new(nil)
+    end
+
+    # Suppress ANY progress indicators
+    def show_progress
+      false
+    end
+  end
+end

--- a/lib/puppet-languageserver/sidecar_protocol.rb
+++ b/lib/puppet-languageserver/sidecar_protocol.rb
@@ -154,12 +154,15 @@ module PuppetLanguageServer
         attr_accessor :doc
         attr_accessor :arity
         attr_accessor :type
+        # The version of this function, typically 3 or 4.
+        attr_accessor :function_version
 
         def to_h
           super.to_h.merge(
-            'doc'   => doc,
-            'arity' => arity,
-            'type'  => type
+            'doc'              => doc,
+            'arity'            => arity,
+            'type'             => type,
+            'function_version' => function_version
           )
         end
 
@@ -169,6 +172,7 @@ module PuppetLanguageServer
           self.doc = value['doc']
           self.arity = value['arity']
           self.type = value['type'].intern
+          self.function_version = value['function_version']
           self
         end
       end

--- a/lib/puppet_languageserver_sidecar.rb
+++ b/lib/puppet_languageserver_sidecar.rb
@@ -275,7 +275,11 @@ module PuppetLanguageServerSidecar
 
     when 'default_types'
       cache = options[:disable_cache] ? PuppetLanguageServerSidecar::Cache::Null.new : PuppetLanguageServerSidecar::Cache::FileSystem.new
-      PuppetLanguageServerSidecar::PuppetHelper.retrieve_types(cache)
+      if use_puppet_strings
+        PuppetLanguageServerSidecar::PuppetHelper.retrieve_via_puppet_strings(cache, :object_types => [:type])[:types]
+      else
+        PuppetLanguageServerSidecar::PuppetHelper.retrieve_types(cache)
+      end
 
     when 'node_graph'
       inject_workspace_as_module || inject_workspace_as_environment
@@ -325,8 +329,15 @@ module PuppetLanguageServerSidecar
     when 'workspace_types'
       null_cache = PuppetLanguageServerSidecar::Cache::Null.new
       return nil unless inject_workspace_as_module || inject_workspace_as_environment
-      PuppetLanguageServerSidecar::PuppetHelper.retrieve_types(null_cache,
-                                                               :root_path => PuppetLanguageServerSidecar::Workspace.root_path)
+      if use_puppet_strings
+        cache = options[:disable_cache] ? PuppetLanguageServerSidecar::Cache::Null.new : PuppetLanguageServerSidecar::Cache::FileSystem.new
+        PuppetLanguageServerSidecar::PuppetHelper.retrieve_via_puppet_strings(cache,
+                                                                              :object_types => [:type],
+                                                                              :root_path    => PuppetLanguageServerSidecar::Workspace.root_path)[:types]
+      else
+        PuppetLanguageServerSidecar::PuppetHelper.retrieve_types(null_cache)
+      end
+
     else
       log_message(:error, "Unknown action #{options[:action]}. Expected one of #{ACTION_LIST}")
     end

--- a/lib/puppet_languageserver_sidecar.rb
+++ b/lib/puppet_languageserver_sidecar.rb
@@ -263,7 +263,11 @@ module PuppetLanguageServerSidecar
 
     when 'default_classes'
       cache = options[:disable_cache] ? PuppetLanguageServerSidecar::Cache::Null.new : PuppetLanguageServerSidecar::Cache::FileSystem.new
-      PuppetLanguageServerSidecar::PuppetHelper.retrieve_classes(cache)
+      if use_puppet_strings
+        PuppetLanguageServerSidecar::PuppetHelper.retrieve_via_puppet_strings(cache, :object_types => [:class])[:classes]
+      else
+        PuppetLanguageServerSidecar::PuppetHelper.retrieve_classes(cache)
+      end
 
     when 'default_functions'
       cache = options[:disable_cache] ? PuppetLanguageServerSidecar::Cache::Null.new : PuppetLanguageServerSidecar::Cache::FileSystem.new
@@ -309,8 +313,15 @@ module PuppetLanguageServerSidecar
     when 'workspace_classes'
       null_cache = PuppetLanguageServerSidecar::Cache::Null.new
       return nil unless inject_workspace_as_module || inject_workspace_as_environment
-      PuppetLanguageServerSidecar::PuppetHelper.retrieve_classes(null_cache,
-                                                                 :root_path => PuppetLanguageServerSidecar::Workspace.root_path)
+      if use_puppet_strings
+        cache = options[:disable_cache] ? PuppetLanguageServerSidecar::Cache::Null.new : PuppetLanguageServerSidecar::Cache::FileSystem.new
+        PuppetLanguageServerSidecar::PuppetHelper.retrieve_via_puppet_strings(cache,
+                                                                              :object_types => [:class],
+                                                                              :root_path    => PuppetLanguageServerSidecar::Workspace.root_path)[:classes]
+      else
+        PuppetLanguageServerSidecar::PuppetHelper.retrieve_classes(null_cache,
+                                                                   :root_path => PuppetLanguageServerSidecar::Workspace.root_path)
+      end
 
     when 'workspace_functions'
       null_cache = PuppetLanguageServerSidecar::Cache::Null.new

--- a/lib/puppet_languageserver_sidecar.rb
+++ b/lib/puppet_languageserver_sidecar.rb
@@ -65,6 +65,11 @@ module PuppetLanguageServerSidecar
         PuppetEditorServices.log_message(:error, "The feature flag 'puppetstrings' has been specified but it is not capable due to Puppet Strings being unavailable. Turning off the flag.")
         flags -= ['puppetstrings']
       end
+      if flags.include?('puppetstrings') && Gem::Version.new(Puppet.version) < Gem::Version.new('6.0.0')
+        # The puppetstrings flag is only valid on Puppet 6.0.0+
+        PuppetEditorServices.log_message(:error, "The feature flag 'puppetstrings' has been specified but it is not capable due to low Puppet version (< 6). Turning off the flag.")
+        flags -= ['puppetstrings']
+      end
       configure_featureflags(flags)
     end
 
@@ -81,6 +86,7 @@ module PuppetLanguageServerSidecar
     if featureflag?('puppetstrings')
       require_list << 'puppet_helper_puppetstrings'
       require_list << 'puppet_monkey_patches_puppetstrings'
+      require_list << 'puppet_strings_helper'
     else
       require_list << 'puppet_helper'
       require_list << 'puppet_monkey_patches'
@@ -216,7 +222,8 @@ module PuppetLanguageServerSidecar
   def self.inject_workspace_as_module
     return false unless PuppetLanguageServerSidecar::Workspace.has_module_metadata?
 
-    Puppet.settings[:basemodulepath] = Puppet.settings[:basemodulepath] + ';' + PuppetLanguageServerSidecar::Workspace.root_path
+    # TODO: Is this really needed?
+    # Puppet.settings[:basemodulepath] = Puppet.settings[:basemodulepath] + ';' + PuppetLanguageServerSidecar::Workspace.root_path
 
     %w[puppet_modulepath_monkey_patches].each do |lib|
       begin
@@ -248,6 +255,8 @@ module PuppetLanguageServerSidecar
   end
 
   def self.execute(options)
+    use_puppet_strings = featureflag?('puppetstrings')
+
     case options[:action].downcase
     when 'noop'
       []
@@ -258,7 +267,11 @@ module PuppetLanguageServerSidecar
 
     when 'default_functions'
       cache = options[:disable_cache] ? PuppetLanguageServerSidecar::Cache::Null.new : PuppetLanguageServerSidecar::Cache::FileSystem.new
-      PuppetLanguageServerSidecar::PuppetHelper.retrieve_functions(cache)
+      if use_puppet_strings
+        PuppetLanguageServerSidecar::PuppetHelper.retrieve_via_puppet_strings(cache, :object_types => [:function])[:functions]
+      else
+        PuppetLanguageServerSidecar::PuppetHelper.retrieve_functions(cache)
+      end
 
     when 'default_types'
       cache = options[:disable_cache] ? PuppetLanguageServerSidecar::Cache::Null.new : PuppetLanguageServerSidecar::Cache::FileSystem.new
@@ -298,8 +311,16 @@ module PuppetLanguageServerSidecar
     when 'workspace_functions'
       null_cache = PuppetLanguageServerSidecar::Cache::Null.new
       return nil unless inject_workspace_as_module || inject_workspace_as_environment
-      PuppetLanguageServerSidecar::PuppetHelper.retrieve_functions(null_cache,
-                                                                   :root_path => PuppetLanguageServerSidecar::Workspace.root_path)
+
+      if use_puppet_strings
+        cache = options[:disable_cache] ? PuppetLanguageServerSidecar::Cache::Null.new : PuppetLanguageServerSidecar::Cache::FileSystem.new
+        PuppetLanguageServerSidecar::PuppetHelper.retrieve_via_puppet_strings(cache,
+                                                                              :object_types => [:function],
+                                                                              :root_path    => PuppetLanguageServerSidecar::Workspace.root_path)[:functions]
+      else
+        PuppetLanguageServerSidecar::PuppetHelper.retrieve_functions(null_cache,
+                                                                     :root_path => PuppetLanguageServerSidecar::Workspace.root_path)
+      end
 
     when 'workspace_types'
       null_cache = PuppetLanguageServerSidecar::Cache::Null.new

--- a/spec/languageserver-sidecar/fixtures/real_agent/cache/lib/puppet/functions/default_pup4_function.rb
+++ b/spec/languageserver-sidecar/fixtures/real_agent/cache/lib/puppet/functions/default_pup4_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API
+# This should be loaded
+Puppet::Functions.create_function(:default_pup4_function) do
+  # @return [Array<String>]
+  def default_pup4_function
+    'default_pup4_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/real_agent/cache/lib/puppet/functions/environment/default_env_pup4_function.rb
+++ b/spec/languageserver-sidecar/fixtures/real_agent/cache/lib/puppet/functions/environment/default_env_pup4_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API
+# This should be loaded in the environment namespace
+Puppet::Functions.create_function(:'environment::default_env_pup4_function') do
+  # @return [Array<String>]
+  def default_env_pup4_function
+    'default_env_pup4_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/real_agent/cache/lib/puppet/functions/modname/default_mod_pup4_function.rb
+++ b/spec/languageserver-sidecar/fixtures/real_agent/cache/lib/puppet/functions/modname/default_mod_pup4_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API
+# This should be loaded in the module called 'modname' namespace
+Puppet::Functions.create_function(:'modname::default_mod_pup4_function') do
+  # @return [Array<String>]
+  def default_mod_pup4_function
+    'default_env_pup4_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/real_agent/environments/testfixtures/modules/defaultmodule/manifests/definedtype.pp
+++ b/spec/languageserver-sidecar/fixtures/real_agent/environments/testfixtures/modules/defaultmodule/manifests/definedtype.pp
@@ -1,4 +1,10 @@
+# This is an example of how to document a defined type.
+# This typename should be fully qualified.
+#
+# @param ensure Ensure parameter documentation.
+# @param param2 param2 documentation.
 define defaultdefinedtype(
-  $ensure       = 'UNSET',
+  $ensure        = 'UNSET',
+  String $param2 = 'param2default'
 ) {
 }

--- a/spec/languageserver-sidecar/fixtures/real_agent/environments/testfixtures/modules/defaultmodule/manifests/init.pp
+++ b/spec/languageserver-sidecar/fixtures/real_agent/environments/testfixtures/modules/defaultmodule/manifests/init.pp
@@ -1,2 +1,12 @@
-class defaultmodule () {
+# This is an example of how to document a Puppet class
+#
+# @example Declaring the class
+#   include example_class
+#
+# @param first The first parameter for this class.
+# @param second The second parameter for this class.
+class defaultmodule (
+  String $first   = 'firstparam',
+  Integer $second = 2,
+) {
 }

--- a/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/badname/pup4_function.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/badname/pup4_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API in a module
+# This should not be loaded in the environment namespace
+Puppet::Functions.create_function(:'badname::pup4_function') do
+  # @return [Array<String>]
+  def pup4_function
+    'pup4_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/profile/pup4_envprofile_function.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/profile/pup4_envprofile_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API in a module
+# This should be loaded in the module namespace
+Puppet::Functions.create_function(:'profile::pup4_envprofile_function') do
+  # @return [Array<String>]
+  def pup4_envprofile_function
+    'pup4_envprofile_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/pup4_env_badfile.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/pup4_env_badfile.rb
@@ -1,0 +1,10 @@
+require 'a_bad_gem_that_does_not_exist'
+
+# Example function using the Puppet 4 API in a module
+# This should not be loaded
+Puppet::Functions.create_function(:pup4_env_badfile) do
+  # @return [Array<String>]
+  def pup4_env_badfile
+    'pup4_env_badfile result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/pup4_env_badfunction.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/pup4_env_badfunction.rb
@@ -1,0 +1,9 @@
+# Example function using the Puppet 4 API in a module
+# This should be loaded but never actually successfully invoke
+Puppet::Functions.create_function(:pup4_env_badfunction) do
+  # @return [Array<String>]
+  def pup4_env_badfunction
+    require 'a_bad_gem_that_does_not_exist'
+    'pup4_env_badfunction result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/pup4_env_function.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/pup4_env_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API in a module
+# ??? This should be loaded as global namespace function
+Puppet::Functions.create_function(:pup4_env_function) do
+  # @return [Array<String>]
+  def pup4_env_function
+    'pup4_env_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/badname/fixture_pup4_env_function.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/badname/fixture_pup4_env_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API in a module
+# This should not be loaded in the module namespace
+Puppet::Functions.create_function(:'badname::fixture_pup4_badname_function') do
+  # @return [Array<String>]
+  def fixture_pup4_badname_function
+    'fixture_pup4_badname_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/fixture_pup4_badfile.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/fixture_pup4_badfile.rb
@@ -1,0 +1,10 @@
+require 'a_bad_gem_that_does_not_exist'
+
+# Example function using the Puppet 4 API in a module
+# This should not be loaded
+Puppet::Functions.create_function(:fixture_pup4_badfile) do
+  # @return [Array<String>]
+  def fixture_pup4_badfile
+    'fixture_pup4_badfile result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/fixture_pup4_badfunction.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/fixture_pup4_badfunction.rb
@@ -1,0 +1,9 @@
+# Example function using the Puppet 4 API in a module
+# This should be loaded but never actually successfully invoke
+Puppet::Functions.create_function(:fixture_pup4_badfunction) do
+  # @return [Array<String>]
+  def fixture_pup4_badfunction
+    require 'a_bad_gem_that_does_not_exist'
+    'fixture_pup4_badfunction result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/fixture_pup4_function.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/fixture_pup4_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API in a module
+# This should be loaded as global namespace function
+Puppet::Functions.create_function(:fixture_pup4_function) do
+  # @return [Array<String>]
+  def fixture_pup4_function
+    'fixture_pup4_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/valid/fixture_pup4_mod_function.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/valid/fixture_pup4_mod_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API in a module
+# This should be loaded in the module namespace
+Puppet::Functions.create_function(:'valid::fixture_pup4_mod_function') do
+  # @return [Array<String>]
+  def fixture_pup4_mod_function
+    'fixture_pup4_mod_function result'
+  end
+end

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_puppetstrings/featureflag_puppetstrings_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_puppetstrings/featureflag_puppetstrings_spec.rb
@@ -2,9 +2,12 @@ require 'spec_helper'
 require 'open3'
 require 'tempfile'
 
-describe 'PuppetLanguageServerSidecar' do
+describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings' do
   def run_sidecar(cmd_options)
     cmd_options << '--no-cache'
+
+    # Append the feature flag
+    cmd_options << '--feature-flag=puppetstrings'
 
     # Append the puppet test-fixtures
     cmd_options << '--puppet-settings'

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_puppetstrings/featureflag_puppetstrings_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_puppetstrings/featureflag_puppetstrings_spec.rb
@@ -215,16 +215,15 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings', :if => G
         # Make sure the type has the right properties
         obj = child_with_key(deserial, :fixture)
         expect(obj.doc).to eq('doc_type_fixture')
-        expect(obj.source).to match(/valid_module_workspace/)
+        expect(obj.source).to match(/valid_module_workspace/)  # TODO THIS IS BROKEN!
         # Make sure the type attributes are correct
         expect(obj.attributes.key?(:name)).to be true
         expect(obj.attributes.key?(:when)).to be true
         expect(obj.attributes[:name][:type]).to eq(:param)
-        expect(obj.attributes[:name][:doc]).to eq("name_parameter\n\n")
-        expect(obj.attributes[:name][:required?]).to be true
+        expect(obj.attributes[:name][:doc]).to eq("name_parameter")
+        expect(obj.attributes[:name][:isnamevar?]).to be true
         expect(obj.attributes[:when][:type]).to eq(:property)
-        expect(obj.attributes[:when][:doc]).to eq("when_property\n\n")
-        expect(obj.attributes[:when][:required?]).to be_nil
+        expect(obj.attributes[:when][:doc]).to eq("when_property")
       end
     end
   end
@@ -327,11 +326,10 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings', :if => G
         expect(obj.attributes.key?(:name)).to be true
         expect(obj.attributes.key?(:when)).to be true
         expect(obj.attributes[:name][:type]).to eq(:param)
-        expect(obj.attributes[:name][:doc]).to eq("name_env_parameter\n\n")
-        expect(obj.attributes[:name][:required?]).to be true
+        expect(obj.attributes[:name][:doc]).to eq("name_env_parameter")
+        expect(obj.attributes[:name][:isnamevar?]).to be true
         expect(obj.attributes[:when][:type]).to eq(:property)
-        expect(obj.attributes[:when][:doc]).to eq("when_env_property\n\n")
-        expect(obj.attributes[:when][:required?]).to be_nil
+        expect(obj.attributes[:when][:doc]).to eq("when_env_property")
       end
     end
   end

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_puppetstrings/featureflag_puppetstrings_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_puppetstrings/featureflag_puppetstrings_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'open3'
 require 'tempfile'
 
-describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings' do
+describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings', :if => Gem::Version.new(Puppet.version) >= Gem::Version.new('6.0.0') do
   def run_sidecar(cmd_options)
     cmd_options << '--no-cache'
 
@@ -48,6 +48,17 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings' do
     end
   end
 
+  def should_not_contain_default_functions(deserial)
+    # These functions should not appear in the deserialised list as they're part
+    # of the default function set, not the workspace.
+    #
+    # They are defined in the fixtures/real_agent/cache/lib/...
+    expect(deserial).to_not contain_child_with_key(:default_cache_function)
+    expect(deserial).to_not contain_child_with_key(:default_pup4_function)
+    expect(deserial).to_not contain_child_with_key(:'environment::default_env_pup4_function')
+    expect(deserial).to_not contain_child_with_key(:'modname::default_mod_pup4_function')
+  end
+
   describe 'when running default_classes action' do
     let (:cmd_options) { ['--action', 'default_classes'] }
 
@@ -81,6 +92,12 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings' do
 
       # These are defined in the fixtures/real_agent/cache/lib/puppet/parser/functions
       expect(deserial).to contain_child_with_key(:default_cache_function)
+      # These are defined in the fixtures/real_agent/cache/lib/puppet/functions
+      expect(deserial).to contain_child_with_key(:default_pup4_function)
+      # These are defined in the fixtures/real_agent/cache/lib/puppet/functions/environment (Special environent namespace)
+      expect(deserial).to contain_child_with_key(:'environment::default_env_pup4_function')
+      # These are defined in the fixtures/real_agent/cache/lib/puppet/functions/modname (module namespaced function)
+      expect(deserial).to contain_child_with_key(:'modname::default_mod_pup4_function')
     end
   end
 
@@ -153,13 +170,34 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings' do
         deserial = PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionList.new()
         expect { deserial.from_json!(result) }.to_not raise_error
 
+        # TODO Turn this in a shared example thingy or at least a function
+        # These are defined in the fixtures/real_agent/cache/lib/...
+        should_not_contain_default_functions(deserial)
+
+        # Puppet 3 API Functions
         expect(deserial).to_not contain_child_with_key(:badfile)
         expect(deserial).to contain_child_with_key(:bad_function)
         expect(deserial).to contain_child_with_key(:fixture_function)
 
+        # Puppet 4 API Functions
+        # The strings based parser will still see 'fixture_pup4_badfile' because it's never _actually_ loaded
+        # in Puppet therefore it will never error
+        expect(deserial).to contain_child_with_key(:fixture_pup4_badfile)
+        # The strings based parser will still see 'badname::fixture_pup4_badname_function' because it's never _actually_ loaded
+        # in Puppet therefore it will never error
+        expect(deserial).to contain_child_with_key(:'badname::fixture_pup4_badname_function')
+        expect(deserial).to contain_child_with_key(:fixture_pup4_function)
+        expect(deserial).to contain_child_with_key(:'valid::fixture_pup4_mod_function')
+        expect(deserial).to contain_child_with_key(:fixture_pup4_badfunction)
+
         # Make sure the function has the right properties
         func = child_with_key(deserial, :fixture_function)
         expect(func.doc).to eq('doc_fixture_function')
+        expect(func.source).to match(/valid_module_workspace/)
+
+        # Make sure the function has the right properties
+        func = child_with_key(deserial, :fixture_pup4_function)
+        expect(func.doc).to match(/Example function using the Puppet 4 API in a module/)
         expect(func.source).to match(/valid_module_workspace/)
       end
     end
@@ -246,11 +284,27 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings' do
         deserial = PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionList.new()
         expect { deserial.from_json!(result) }.to_not raise_error
 
+        should_not_contain_default_functions(deserial)
+
+        # The strings based parser will still see 'pup4_env_badfile' because it's never _actually_ loaded
+        # in Puppet therefore it will never error
+        expect(deserial).to contain_child_with_key(:pup4_env_badfile)
+        # The strings based parser will still see 'badname::pup4_function' because it's never _actually_ loaded
+        # in Puppet therefore it will never error
+        expect(deserial).to contain_child_with_key(:'badname::pup4_function')
         expect(deserial).to contain_child_with_key(:env_function)
+        expect(deserial).to contain_child_with_key(:pup4_env_function)
+        expect(deserial).to contain_child_with_key(:pup4_env_badfunction)
+        expect(deserial).to contain_child_with_key(:'profile::pup4_envprofile_function')
 
         # Make sure the function has the right properties
         func = child_with_key(deserial, :env_function)
         expect(func.doc).to eq('doc_env_function')
+        expect(func.source).to match(/valid_environment_workspace/)
+
+        # Make sure the function has the right properties
+        func = child_with_key(deserial, :pup4_env_function)
+        expect(func.doc).to match(/Example function using the Puppet 4 API in a module/)
         expect(func.source).to match(/valid_environment_workspace/)
       end
     end

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_puppetstrings/featureflag_puppetstrings_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_puppetstrings/featureflag_puppetstrings_spec.rb
@@ -73,6 +73,25 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings', :if => G
       # These are defined in the fixtures/real_agent/environments/testfixtures/modules/defaultmodule
       expect(deserial).to contain_child_with_key(:defaultdefinedtype)
       expect(deserial).to contain_child_with_key(:defaultmodule)
+
+      # Make sure the classes have the right properties
+      obj = child_with_key(deserial, :defaultdefinedtype)
+      expect(obj.doc).to match(/This is an example of how to document a defined type/)
+      expect(obj.source).to match(/defaultmodule/)
+      expect(obj.parameters.count).to eq 2
+      expect(obj.parameters['ensure'][:type]).to eq 'Any'
+      expect(obj.parameters['ensure'][:doc]).to match(/Ensure parameter documentation/)
+      expect(obj.parameters['param2'][:type]).to eq 'String'
+      expect(obj.parameters['param2'][:doc]).to match(/param2 documentation/)
+
+      obj = child_with_key(deserial, :defaultmodule)
+      expect(obj.doc).to match(/This is an example of how to document a Puppet class/)
+      expect(obj.source).to match(/defaultmodule/)
+      expect(obj.parameters.count).to eq 2
+      expect(obj.parameters['first'][:type]).to eq 'String'
+      expect(obj.parameters['first'][:doc]).to match(/The first parameter for this class/)
+      expect(obj.parameters['second'][:type]).to eq 'Integer'
+      expect(obj.parameters['second'][:doc]).to match(/The second parameter for this class/)
     end
   end
 
@@ -265,13 +284,6 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings', :if => G
         expect(deserial).to contain_child_with_key(:"profile::main")
         # Defined Types
         expect(deserial).to contain_child_with_key(:envdeftype)
-
-        # Make sure the class has the right properties
-        obj = child_with_key(deserial, :envdeftype)
-        expect(obj.doc).to be_nil # We don't yet get documentation for classes or defined types
-        expect(obj.parameters['ensure']).to_not be_nil
-        expect(obj.parameters['ensure'][:type]).to eq('String')
-        expect(obj.source).to match(/valid_environment_workspace/)
       end
     end
 

--- a/spec/languageserver/spec_helper.rb
+++ b/spec/languageserver/spec_helper.rb
@@ -70,6 +70,7 @@ def random_sidecar_puppet_function
   result.doc = 'doc' + rand(1000).to_s
   result.arity = rand(1000)
   result.type = ('type' + rand(1000).to_s).intern
+  result.function_version = rand(1) + 3
   result
 end
 

--- a/spec/languageserver/unit/puppet-languageserver/sidecar_protocol_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/sidecar_protocol_spec.rb
@@ -55,7 +55,7 @@ describe 'PuppetLanguageServer::Sidecar::Protocol' do
   basepuppetobject_properties = [:key, :calling_source, :source, :line, :char, :length]
   nodegraph_properties = [:dot_content, :error_content]
   puppetclass_properties = [:doc, :parameters]
-  puppetfunction_properties = [:doc, :arity, :type]
+  puppetfunction_properties = [:doc, :arity, :type, :function_version]
   puppettype_properties = [:doc, :attributes]
   resource_properties = [:manifest]
 


### PR DESCRIPTION
WIP

TODO

- [x] uncomplicate the the Yard extraction of puppet classes / defined types
- [x] Rubocop
- [x] Remove methods in the puppet helper instead of commenting out
- [ ] Add more tests for documentation of classes? (types not being an array? what if things are missing? should I be using symbols instead of strings?)
- [ ] Address all TODOs in source
- [x] Extract initial Puppet Strings helper into separate commit
- [x] "Rebase" my original copy of the puppet_helper and monkeypatch file from upstream master.  It inherited a bunch of rubocop errors. Pending merge of PR 124