### PR TITLE
(GH-121) Load Puppet Functions via Puppet API v4 and present as Puppet API v3 functions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,10 @@ group :development do
   else
     gem 'puppet',                            :require => false
   end
+  # TODO: This should be vendored into Editor Services after it is no longer a feature flag
+  # The puppet-strings gem is not available in the Puppet Agent, but is in the PDK. We add it to the
+  # Gemfile here for testing and development.
+  gem "puppet-strings", "~> 2.0", :require => false
 
   case RUBY_PLATFORM
   when /darwin/

--- a/lib/puppet-languageserver-sidecar/cache/base.rb
+++ b/lib/puppet-languageserver-sidecar/cache/base.rb
@@ -5,6 +5,7 @@ module PuppetLanguageServerSidecar
     CLASSES_SECTION = 'classes'
     FUNCTIONS_SECTION = 'functions'
     TYPES_SECTION = 'types'
+    PUPPETSTRINGS_SECTION = 'puppetstrings'
 
     class Base
       attr_reader :cache_options
@@ -22,6 +23,12 @@ module PuppetLanguageServerSidecar
       end
 
       def save(_absolute_path, _section, _content_string)
+        raise NotImplementedError
+      end
+
+      # WARNING - This method is only intended for testing the cache
+      # and should not be used for normal operations
+      def clear!
         raise NotImplementedError
       end
     end

--- a/lib/puppet-languageserver-sidecar/cache/null.rb
+++ b/lib/puppet-languageserver-sidecar/cache/null.rb
@@ -18,6 +18,10 @@ module PuppetLanguageServerSidecar
       def save(*)
         true
       end
+
+      def clear!
+        nil
+      end
     end
   end
 end

--- a/lib/puppet-languageserver-sidecar/puppet_helper_puppetstrings.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_helper_puppetstrings.rb
@@ -1,0 +1,359 @@
+# frozen_string_literal: true
+
+require 'puppet/indirector/face'
+
+module PuppetLanguageServerSidecar
+  module PuppetHelper
+    SIDECAR_PUPPET_ENVIRONMENT = 'sidecarenvironment'
+
+    def self.path_has_child?(path, child)
+      # Doesn't matter what the child is, if the path is nil it's true.
+      return true if path.nil?
+      return false if path.length >= child.length
+
+      value = child.slice(0, path.length)
+      return true if value.casecmp(path).zero?
+      false
+    end
+
+    # Resource Face
+    def self.get_puppet_resource(typename, title = nil)
+      result = PuppetLanguageServer::Sidecar::Protocol::PuppetClassList.new
+      if title.nil?
+        resources = Puppet::Face[:resource, '0.0.1'].search(typename)
+      else
+        resources = Puppet::Face[:resource, '0.0.1'].find("#{typename}/#{title}")
+      end
+      return result if resources.nil?
+      resources = [resources] unless resources.is_a?(Array)
+      prune_resource_parameters(resources).each do |item|
+        obj = PuppetLanguageServer::Sidecar::Protocol::Resource.new
+        obj.manifest = item.to_manifest
+        result << obj
+      end
+      result
+    end
+
+    # Class and Defined Type loading
+    def self.retrieve_classes(cache, options = {})
+      PuppetLanguageServerSidecar.log_message(:debug, '[PuppetHelper::retrieve_classes] Starting')
+
+      # TODO: Can probably do this better, but this works.
+      current_env = current_environment
+      module_path_list = current_env
+                         .modules
+                         .select { |mod| Dir.exist?(File.join(mod.path, 'manifests')) }
+                         .map { |mod| mod.path }
+      manifest_path_list = module_path_list.map { |mod_path| File.join(mod_path, 'manifests') }
+      PuppetLanguageServerSidecar.log_message(:debug, "[PuppetHelper::retrieve_classes] Loading classes from #{module_path_list}")
+
+      # Find and parse all manifests in the manifest paths
+      classes = PuppetLanguageServer::Sidecar::Protocol::PuppetClassList.new
+      manifest_path_list.each do |manifest_path|
+        Dir.glob("#{manifest_path}/**/*.pp").each do |manifest_file|
+          begin
+            if path_has_child?(options[:root_path], manifest_file) # rubocop:disable Style/IfUnlessModifier  Nicer to read like this
+              classes.concat(load_classes_from_manifest(cache, manifest_file))
+            end
+          rescue StandardError => e
+            PuppetLanguageServerSidecar.log_message(:error, "[PuppetHelper::retrieve_classes] Error loading manifest #{manifest_file}: #{e} #{e.backtrace}")
+          end
+        end
+      end
+
+      PuppetLanguageServerSidecar.log_message(:debug, "[PuppetHelper::retrieve_classes] Finished loading #{classes.count} classes")
+      classes
+    end
+
+    # Function loading
+    def self.retrieve_functions(cache, options = {})
+      PuppetLanguageServerSidecar.log_message(:debug, '[PuppetHelper::load_functions] Starting')
+
+      autoloader = Puppet::Util::Autoload.new(self, 'puppet/parser/functions')
+      current_env = current_environment
+      funcs = PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionList.new
+
+      # Functions that are already loaded (e.g. system default functions like alert)
+      # should already be populated so insert them into the function results
+      #
+      # Find the unique filename list
+      filenames = []
+      Puppet::Parser::Functions.monkey_function_list.each_value do |data|
+        filenames << data[:source_location][:source] unless data[:source_location].nil? || data[:source_location][:source].nil?
+      end
+      # Now add the functions in each file to the cache
+      filenames.uniq.compact.each do |filename|
+        Puppet::Parser::Functions.monkey_function_list
+                                 .select { |_k, i| filename.casecmp(i[:source_location][:source].to_s).zero? }
+                                 .select { |_k, i| path_has_child?(options[:root_path], i[:source_location][:source]) }
+                                 .each do |name, item|
+          obj = PuppetLanguageServerSidecar::Protocol::PuppetFunction.from_puppet(name, item)
+          funcs << obj
+        end
+      end
+
+      # Now we can load functions from the default locations
+      if autoloader.method(:files_to_load).arity.zero?
+        params = []
+      else
+        params = [current_env]
+      end
+      autoloader.files_to_load(*params).each do |file|
+        name = file.gsub(autoloader.path + '/', '')
+        begin
+          expanded_name = autoloader.expand(name)
+          absolute_name = Puppet::Util::Autoload.get_file(expanded_name, current_env)
+          raise("Could not find absolute path of function #{name}") if absolute_name.nil?
+          if path_has_child?(options[:root_path], absolute_name) # rubocop:disable Style/IfUnlessModifier  Nicer to read like this
+            funcs.concat(load_function_file(cache, name, absolute_name, autoloader, current_env))
+          end
+        rescue StandardError => e
+          PuppetLanguageServerSidecar.log_message(:error, "[PuppetHelper::load_functions] Error loading function #{file}: #{e} #{e.backtrace}")
+        end
+      end
+
+      PuppetLanguageServerSidecar.log_message(:debug, "[PuppetHelper::load_functions] Finished loading #{funcs.count} functions")
+      funcs
+    end
+
+    def self.retrieve_types(cache, options = {})
+      PuppetLanguageServerSidecar.log_message(:debug, '[PuppetHelper::retrieve_types] Starting')
+
+      # From https://github.com/puppetlabs/puppet/blob/ebd96213cab43bb2a8071b7ac0206c3ed0be8e58/lib/puppet/metatype/manager.rb#L182-L189
+      autoloader = Puppet::Util::Autoload.new(self, 'puppet/type')
+      current_env = current_environment
+      types = PuppetLanguageServer::Sidecar::Protocol::PuppetTypeList.new
+
+      # This is an expensive call
+      if autoloader.method(:files_to_load).arity.zero?
+        params = []
+      else
+        params = [current_env]
+      end
+      autoloader.files_to_load(*params).each do |file|
+        name = file.gsub(autoloader.path + '/', '')
+        begin
+          expanded_name = autoloader.expand(name)
+          absolute_name = Puppet::Util::Autoload.get_file(expanded_name, current_env)
+          raise("Could not find absolute path of type #{name}") if absolute_name.nil?
+          if path_has_child?(options[:root_path], absolute_name) # rubocop:disable Style/IfUnlessModifier  Nicer to read like this
+            types.concat(load_type_file(cache, name, absolute_name, autoloader, current_env))
+          end
+        rescue StandardError => e
+          PuppetLanguageServerSidecar.log_message(:error, "[PuppetHelper::retrieve_types] Error loading type #{file}: #{e} #{e.backtrace}")
+        end
+      end
+
+      PuppetLanguageServerSidecar.log_message(:debug, "[PuppetHelper::retrieve_types] Finished loading #{types.count} type/s")
+
+      types
+    end
+
+    # Private functions
+
+    def self.prune_resource_parameters(resources)
+      # From https://github.com/puppetlabs/puppet/blob/488661d84e54904124514ab9e4500e81b10f84d1/lib/puppet/application/resource.rb#L146-L148
+      if resources.is_a?(Array)
+        resources.map(&:prune_parameters)
+      else
+        resources.prune_parameters
+      end
+    end
+    private_class_method :prune_resource_parameters
+
+    def self.current_environment
+      begin
+        env = Puppet.lookup(:environments).get!(Puppet.settings[:environment])
+        return env unless env.nil?
+      rescue Puppet::Environments::EnvironmentNotFound
+        PuppetLanguageServerSidecar.log_message(:warning, "[PuppetHelper::current_environment] Unable to load environment #{Puppet.settings[:environment]}")
+      rescue StandardError => e
+        PuppetLanguageServerSidecar.log_message(:warning, "[PuppetHelper::current_environment] Error loading environment #{Puppet.settings[:environment]}: #{e}")
+      end
+      Puppet.lookup(:current_environment)
+    end
+    private_class_method :current_environment
+
+    def self.load_classes_from_manifest(cache, manifest_file)
+      class_info = PuppetLanguageServer::Sidecar::Protocol::PuppetClassList.new
+
+      if cache.active?
+        cached_result = cache.load(manifest_file, PuppetLanguageServerSidecar::Cache::CLASSES_SECTION)
+        unless cached_result.nil?
+          begin
+            class_info.from_json!(cached_result)
+            return class_info
+          rescue StandardError => e
+            PuppetLanguageServerSidecar.log_message(:warn, "[PuppetHelper::load_classes_from_manifest] Error while deserializing #{manifest_file} from cache: #{e}")
+            class_info = PuppetLanguageServer::Sidecar::Protocol::PuppetClassList.new
+          end
+        end
+      end
+
+      file_content = File.open(manifest_file, 'r:UTF-8') { |f| f.read }
+
+      parser = Puppet::Pops::Parser::Parser.new
+      result = nil
+      begin
+        result = parser.parse_string(file_content, '')
+      rescue Puppet::ParseErrorWithIssue
+        # Any parsing errors means we can't inspect the document
+        return class_info
+      end
+
+      # Enumerate the entire AST looking for classes and defined types
+      # TODO: Need to learn how to read the help/docs for hover support
+      if result.model.respond_to? :eAllContents
+        # Puppet 4 AST
+        result.model.eAllContents.select do |item|
+          puppet_class = {}
+          case item.class.to_s
+          when 'Puppet::Pops::Model::HostClassDefinition'
+            puppet_class['type'] = :class
+          when 'Puppet::Pops::Model::ResourceTypeDefinition'
+            puppet_class['type'] = :typedefinition
+          else
+            next
+          end
+          puppet_class['name']       = item.name
+          puppet_class['doc']        = nil
+          puppet_class['parameters'] = item.parameters
+          puppet_class['source']     = manifest_file
+          puppet_class['line']       = result.locator.line_for_offset(item.offset) - 1
+          puppet_class['char']       = result.locator.offset_on_line(item.offset)
+
+          obj = PuppetLanguageServerSidecar::Protocol::PuppetClass.from_puppet(item.name, puppet_class, result.locator)
+          class_info << obj
+        end
+      else
+        result.model._pcore_all_contents([]) do |item|
+          puppet_class = {}
+          case item.class.to_s
+          when 'Puppet::Pops::Model::HostClassDefinition'
+            puppet_class['type'] = :class
+          when 'Puppet::Pops::Model::ResourceTypeDefinition'
+            puppet_class['type'] = :typedefinition
+          else
+            next
+          end
+          puppet_class['name']       = item.name
+          puppet_class['doc']        = nil
+          puppet_class['parameters'] = item.parameters
+          puppet_class['source']     = manifest_file
+          puppet_class['line']       = item.line
+          puppet_class['char']       = item.pos
+          obj = PuppetLanguageServerSidecar::Protocol::PuppetClass.from_puppet(item.name, puppet_class, item.locator)
+          class_info << obj
+        end
+      end
+      cache.save(manifest_file, PuppetLanguageServerSidecar::Cache::CLASSES_SECTION, class_info.to_json) if cache.active?
+
+      class_info
+    end
+    private_class_method :load_classes_from_manifest
+
+    def self.load_function_file(cache, name, absolute_name, autoloader, env)
+      funcs = PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionList.new
+
+      if cache.active?
+        cached_result = cache.load(absolute_name, PuppetLanguageServerSidecar::Cache::FUNCTIONS_SECTION)
+        unless cached_result.nil?
+          begin
+            funcs.from_json!(cached_result)
+            return funcs
+          rescue StandardError => e
+            PuppetLanguageServerSidecar.log_message(:warn, "[PuppetHelper::load_function_file] Error while deserializing #{absolute_name} from cache: #{e}")
+            funcs = PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionList.new
+          end
+        end
+      end
+
+      unless autoloader.loaded?(name)
+        # This is an expensive call
+        unless autoloader.load(name, env) # rubocop:disable Style/IfUnlessModifier  Nicer to read like this
+          PuppetLanguageServerSidecar.log_message(:error, "[PuppetHelper::load_function_file] function #{absolute_name} did not load")
+        end
+      end
+
+      # Find the functions that were loaded based on source file name (case insensitive)
+      Puppet::Parser::Functions.monkey_function_list
+                               .select { |_k, i| absolute_name.casecmp(i[:source_location][:source].to_s).zero? }
+                               .each do |func_name, item|
+        obj = PuppetLanguageServerSidecar::Protocol::PuppetFunction.from_puppet(func_name, item)
+        obj.calling_source = absolute_name
+        funcs << obj
+      end
+      PuppetLanguageServerSidecar.log_message(:warn, "[PuppetHelper::load_function_file] file #{absolute_name} did load any functions") if funcs.count.zero?
+      cache.save(absolute_name, PuppetLanguageServerSidecar::Cache::FUNCTIONS_SECTION, funcs.to_json) if cache.active?
+
+      funcs
+    end
+    private_class_method :load_function_file
+
+    def self.load_type_file(cache, name, absolute_name, autoloader, env)
+      types = PuppetLanguageServer::Sidecar::Protocol::PuppetTypeList.new
+      if cache.active?
+        cached_result = cache.load(absolute_name, PuppetLanguageServerSidecar::Cache::TYPES_SECTION)
+        unless cached_result.nil?
+          begin
+            types.from_json!(cached_result)
+            return types
+          rescue StandardError => e
+            PuppetLanguageServerSidecar.log_message(:warn, "[PuppetHelper::load_type_file] Error while deserializing #{absolute_name} from cache: #{e}")
+            types = PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionList.new
+          end
+        end
+      end
+
+      # Get the list of currently loaded types
+      loaded_types = []
+      # Due to PUP-8301, if no types have been loaded yet then Puppet::Type.eachtype
+      # will throw instead of not yielding.
+      begin
+        Puppet::Type.eachtype { |item| loaded_types << item.name }
+      rescue NoMethodError => e
+        # Detect PUP-8301
+        if e.respond_to?(:receiver)
+          raise unless e.name == :each && e.receiver.nil?
+        else
+          raise unless e.name == :each && e.message =~ /nil:NilClass/
+        end
+      end
+
+      unless autoloader.loaded?(name)
+        # This is an expensive call
+        unless autoloader.load(name, env) # rubocop:disable Style/IfUnlessModifier  Nicer to read like this
+          PuppetLanguageServerSidecar.log_message(:error, "[PuppetHelper::load_type_file] type #{absolute_name} did not load")
+        end
+      end
+
+      # Find the types that were loaded
+      # Due to PUP-8301, if no types have been loaded yet then Puppet::Type.eachtype
+      # will throw instead of not yielding.
+      begin
+        Puppet::Type.eachtype do |item|
+          next if loaded_types.include?(item.name)
+          # Ignore the internal only Puppet Types
+          next if item.name == :component || item.name == :whit
+          obj = PuppetLanguageServerSidecar::Protocol::PuppetType.from_puppet(item.name, item)
+          # TODO: Need to use calling_source in the cache backing store
+          # Perhaps I should be incrementally adding items to the cache instead of batch mode?
+          obj.calling_source = absolute_name
+          types << obj
+        end
+      rescue NoMethodError => e
+        # Detect PUP-8301
+        if e.respond_to?(:receiver)
+          raise unless e.name == :each && e.receiver.nil?
+        else
+          raise unless e.name == :each && e.message =~ /nil:NilClass/
+        end
+      end
+      PuppetLanguageServerSidecar.log_message(:warn, "[PuppetHelper::load_type_file] type #{absolute_name} did not load any types") if types.empty?
+      cache.save(absolute_name, PuppetLanguageServerSidecar::Cache::TYPES_SECTION, types.to_json) if cache.active?
+
+      types
+    end
+    private_class_method :load_type_file
+  end
+end

--- a/lib/puppet-languageserver-sidecar/puppet_helper_puppetstrings.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_helper_puppetstrings.rb
@@ -40,7 +40,7 @@ module PuppetLanguageServerSidecar
     end
 
     # Retrieve objects via the Puppet 4 API loaders
-    def self.retrieve_via_puppet_strings(_cache, options = {})
+    def self.retrieve_via_puppet_strings(cache, options = {})
       PuppetLanguageServerSidecar.log_message(:debug, '[PuppetHelper::retrieve_via_puppet_strings] Starting')
 
       object_types = options[:object_types].nil? ? available_documentation_types : options[:object_types]
@@ -60,7 +60,7 @@ module PuppetLanguageServerSidecar
 
       paths.each do |path|
         next unless path_has_child?(options[:root_path], path)
-        file_doc = PuppetLanguageServerSidecar::PuppetStringsHelper.file_documentation(path)
+        file_doc = PuppetLanguageServerSidecar::PuppetStringsHelper.file_documentation(path, cache)
         next if file_doc.nil?
 
         if object_types.include?(:function) # rubocop:disable Style/IfUnlessModifier   This reads better

--- a/lib/puppet-languageserver-sidecar/puppet_monkey_patches_puppetstrings.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_monkey_patches_puppetstrings.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+# Monkey Patch 3.x functions so where know where they were loaded from
+require 'puppet/parser/functions'
+module Puppet
+  module Parser
+    module Functions
+      class << self
+        alias_method :original_newfunction, :newfunction
+        def newfunction(name, options = {}, &block)
+          # See if we've hooked elsewhere. This can happen while in debuggers (pry). If we're not in the previous caller
+          # stack then just use the last caller
+          monkey_index = Kernel.caller_locations.find_index { |loc| loc.path.match(/puppet_monkey_patches\.rb/) }
+          monkey_index = -1 if monkey_index.nil?
+          caller = Kernel.caller_locations[monkey_index + 1]
+          # Call the original new function method
+          result = original_newfunction(name, options, &block)
+          # Append the caller information
+          result[:source_location] = {
+            :source => caller.absolute_path,
+            :line   => caller.lineno - 1 # Convert to a zero based line number system
+          }
+          monkey_append_function_info(name, result)
+
+          result
+        end
+
+        def monkey_clear_function_info
+          @monkey_function_list = {}
+        end
+
+        def monkey_append_function_info(name, value)
+          @monkey_function_list = {} if @monkey_function_list.nil?
+          @monkey_function_list[name] = {
+            :arity           => value[:arity],
+            :name            => value[:name],
+            :type            => value[:type],
+            :doc             => value[:doc],
+            :source_location => value[:source_location]
+          }
+        end
+
+        def monkey_function_list
+          @monkey_function_list = {} if @monkey_function_list.nil?
+          @monkey_function_list.clone
+        end
+      end
+    end
+  end
+end
+
+# Add an additional method on Puppet Types to store their source location
+require 'puppet/type'
+module Puppet
+  class Type
+    class << self
+      attr_accessor :_source_location
+    end
+  end
+end
+
+# Monkey Patch type loading so we can inject the source location information
+require 'puppet/metatype/manager'
+module Puppet
+  module MetaType
+    module Manager
+      alias_method :original_newtype, :newtype
+      def newtype(name, options = {}, &block)
+        result = original_newtype(name, options, &block)
+
+        if block_given? && !block.source_location.nil?
+          result._source_location = {
+            :source => block.source_location[0],
+            :line   => block.source_location[1] - 1 # Convert to a zero based line number system
+          }
+        end
+        result
+      end
+    end
+  end
+end
+
+# MUST BE LAST!!!!!!
+# Suppress any warning messages to STDOUT.  It can pollute stdout when running in STDIO mode
+Puppet::Util::Log.newdesttype :null_logger do
+  def handle(msg)
+    PuppetLanguageServerSidecar.log_message(:debug, "[PUPPET LOG] [#{msg.level}] #{msg.message}")
+  end
+end

--- a/lib/puppet-languageserver-sidecar/puppet_monkey_patches_puppetstrings.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_monkey_patches_puppetstrings.rb
@@ -1,54 +1,5 @@
 # frozen_string_literal: true
 
-# Monkey Patch 3.x functions so where know where they were loaded from
-require 'puppet/parser/functions'
-module Puppet
-  module Parser
-    module Functions
-      class << self
-        alias_method :original_newfunction, :newfunction
-        def newfunction(name, options = {}, &block)
-          # See if we've hooked elsewhere. This can happen while in debuggers (pry). If we're not in the previous caller
-          # stack then just use the last caller
-          monkey_index = Kernel.caller_locations.find_index { |loc| loc.path.match(/puppet_monkey_patches\.rb/) }
-          monkey_index = -1 if monkey_index.nil?
-          caller = Kernel.caller_locations[monkey_index + 1]
-          # Call the original new function method
-          result = original_newfunction(name, options, &block)
-          # Append the caller information
-          result[:source_location] = {
-            :source => caller.absolute_path,
-            :line   => caller.lineno - 1 # Convert to a zero based line number system
-          }
-          monkey_append_function_info(name, result)
-
-          result
-        end
-
-        def monkey_clear_function_info
-          @monkey_function_list = {}
-        end
-
-        def monkey_append_function_info(name, value)
-          @monkey_function_list = {} if @monkey_function_list.nil?
-          @monkey_function_list[name] = {
-            :arity           => value[:arity],
-            :name            => value[:name],
-            :type            => value[:type],
-            :doc             => value[:doc],
-            :source_location => value[:source_location]
-          }
-        end
-
-        def monkey_function_list
-          @monkey_function_list = {} if @monkey_function_list.nil?
-          @monkey_function_list.clone
-        end
-      end
-    end
-  end
-end
-
 # Add an additional method on Puppet Types to store their source location
 require 'puppet/type'
 module Puppet
@@ -75,6 +26,83 @@ module Puppet
           }
         end
         result
+      end
+    end
+  end
+end
+
+if Gem::Version.new(Puppet.version) >= Gem::Version.new('6.0.0')
+  # Due to PUP-9509, need to monkey patch the cache loader
+  # This need to be guarded on Puppet 6.0.0+
+  require 'puppet/pops/loader/module_loaders'
+  module Puppet
+    module Pops
+      module Loader
+        module ModuleLoaders
+          def self.cached_loader_from(parent_loader, loaders)
+            LibRootedFileBased.new(parent_loader,
+                                   loaders,
+                                   NAMESPACE_WILDCARD,
+                                   Puppet[:libdir],
+                                   'cached_puppet_lib',
+                                   %i[func_4x func_3x datatype])
+          end
+        end
+      end
+    end
+  end
+end
+
+module Puppet
+  module Pops
+    module Loader
+      class Loader
+        def discover_paths(type, name_authority = Pcore::RUNTIME_NAME_AUTHORITY)
+          if parent.nil?
+            []
+          else
+            parent.discover_paths(type, name_authority)
+          end
+        end
+      end
+    end
+  end
+end
+
+module Puppet
+  module Pops
+    module Loader
+      class DependencyLoader
+        def discover_paths(type, name_authority = Pcore::RUNTIME_NAME_AUTHORITY)
+          result = []
+
+          @dependency_loaders.each { |loader| result.concat(loader.discover_paths(type, name_authority)) }
+          result.concat(super)
+          result.uniq
+        end
+      end
+    end
+  end
+end
+
+module Puppet
+  module Pops
+    module Loader
+      module ModuleLoaders
+        class AbstractPathBasedModuleLoader
+          def discover_paths(type, name_authority = Pcore::RUNTIME_NAME_AUTHORITY)
+            result = []
+            if name_authority == Pcore::RUNTIME_NAME_AUTHORITY
+              smart_paths.effective_paths(type).each do |sp|
+                relative_paths(sp).each do |rp|
+                  result << File.join(sp.generic_path, rp)
+                end
+              end
+            end
+            result.concat(super)
+            result.uniq
+          end
+        end
       end
     end
   end

--- a/lib/puppet-languageserver-sidecar/puppet_strings_helper.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_strings_helper.rb
@@ -10,6 +10,7 @@ module PuppetLanguageServerSidecar
       return nil unless require_puppet_strings
       @helper_cache = FileDocumentationCache.new if @helper_cache.nil?
       return @helper_cache.document(path) if @helper_cache.path_exists?(path)
+
       PuppetLanguageServerSidecar.log_message(:debug, "[PuppetStringsHelper::file_documentation] Fetching documentation for #{path}")
 
       setup_yard!
@@ -80,16 +81,62 @@ module PuppetLanguageServerSidecar
     def populate_from_yard_registry!
       # Extract all of the information
       # Ref - https://github.com/puppetlabs/puppet-strings/blob/87a8e10f45bfeb7b6b8e766324bfb126de59f791/lib/puppet-strings/json.rb#L10-L16
+      populate_functions_from_yard_registry!
     end
 
     private
 
+    def populate_functions_from_yard_registry!
+      ::YARD::Registry.all(:puppet_function).map(&:to_hash).each do |item|
+        source_path = item[:file]
+        func_name = item[:name].to_s
+        @cache[source_path] = FileDocumentation.new(source_path) if @cache[source_path].nil?
+
+        obj                  = PuppetLanguageServer::Sidecar::Protocol::PuppetFunction.new
+        obj.key              = func_name
+        obj.source           = item[:file]
+        obj.calling_source   = obj.source
+        obj.line             = item[:line]
+        obj.doc              = item[:docstring][:text]
+        obj.arity            = -1 # We don't care about arity
+        obj.function_version = item[:type] == 'ruby4x' ? 4 : 3
+
+        # Try and determine the function call site from the source file
+        char = item[:source].index(":#{func_name}")
+        unless char.nil?
+          obj.char = char
+          obj.length = func_name.length + 1
+        end
+
+        case item[:type]
+        when 'ruby3x'
+          obj.function_version = 3
+          # This is a bit hacky but it works (probably).  Puppet-Strings doesn't rip this information out, but you do have the
+          # the source to query
+          obj.type = item[:source].match(/:rvalue/) ? :rvalue : :statement
+        when 'ruby4x'
+          obj.function_version = 4
+          # All ruby functions are statements
+          obj.type = :statement
+        else
+          PuppetLanguageServerSidecar.log_message(:error, "[#{self.class}] Unknown function type #{item[:type]}")
+        end
+
+        @cache[source_path].functions << obj
+      end
+    end
+  end
+
   class FileDocumentation
     # The path to file that has been documented
-    attr_reader :path
+    attr_accessor :path
 
-    def initialize(path)
+    # PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionList object holding all functions
+    attr_accessor :functions
+
+    def initialize(path = nil)
       @path = path
+      @functions = PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionList.new
     end
   end
 end

--- a/lib/puppet-languageserver-sidecar/puppet_strings_helper.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_strings_helper.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module PuppetLanguageServerSidecar
+  module PuppetStringsHelper
+    # Returns a FileDocumentation object for a given path
+    #
+    # @param [String] path The absolute path to the file that will be documented
+    # @return [FileDocumentation, nil] Returns the documentation for the path, or nil if it cannot be extracted
+    def self.file_documentation(path)
+      return nil unless require_puppet_strings
+      @helper_cache = FileDocumentationCache.new if @helper_cache.nil?
+      return @helper_cache.document(path) if @helper_cache.path_exists?(path)
+      PuppetLanguageServerSidecar.log_message(:debug, "[PuppetStringsHelper::file_documentation] Fetching documentation for #{path}")
+
+      setup_yard!
+
+      # For now, assume a single file path
+      search_patterns = [path]
+
+      # Format the arguments to YARD
+      args = ['doc']
+      args << '--no-output'
+      args << '--quiet'
+      args << '--no-stats'
+      args << '--no-progress'
+      args << '--no-save'
+      args << '--api public'
+      args << '--api private'
+      args << '--no-api'
+      args += search_patterns
+
+      # Run YARD
+      ::YARD::CLI::Yardoc.run(*args)
+
+      # Populate the documentation cache from the YARD information
+      @helper_cache.populate_from_yard_registry!
+
+      # Return the documentation details
+      @helper_cache.document(path)
+    end
+
+    def self.require_puppet_strings
+      return @puppet_strings_loaded unless @puppet_strings_loaded.nil?
+      begin
+        require 'puppet-strings'
+        require 'puppet-strings/yard'
+        require 'puppet-strings/json'
+        @puppet_strings_loaded = true
+      rescue LoadError => e
+        PuppetLanguageServerSidecar.log_message(:error, "[PuppetStringsHelper::require_puppet_strings] Unable to load puppet-strings gem: #{e}")
+        @puppet_strings_loaded = false
+      end
+      @puppet_strings_loaded
+    end
+    private_class_method :require_puppet_strings
+
+    def self.setup_yard!
+      unless @yard_setup # rubocop:disable Style/GuardClause
+        ::PuppetStrings::Yard.setup!
+        @yard_setup = true
+      end
+    end
+    private_class_method :setup_yard!
+  end
+
+  class FileDocumentationCache
+    def initialize
+      # Hash of <[String] path, FileDocumentation> objects
+      @cache = {}
+    end
+
+    def path_exists?(path)
+      @cache.key?(path)
+    end
+
+    def document(path)
+      @cache[path]
+    end
+
+    def populate_from_yard_registry!
+      # Extract all of the information
+      # Ref - https://github.com/puppetlabs/puppet-strings/blob/87a8e10f45bfeb7b6b8e766324bfb126de59f791/lib/puppet-strings/json.rb#L10-L16
+    end
+
+    private
+
+  class FileDocumentation
+    # The path to file that has been documented
+    attr_reader :path
+
+    def initialize(path)
+      @path = path
+    end
+  end
+end

--- a/lib/puppet-languageserver-sidecar/puppet_strings_monkey_patches.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_strings_monkey_patches.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'yard/logging'
+module YARD
+  class Logger < ::Logger
+    # Suppress ANY output
+    def self.instance(_pipe = STDOUT)
+      @logger ||= new(nil)
+    end
+
+    # Suppress ANY progress indicators
+    def show_progress
+      false
+    end
+  end
+end

--- a/lib/puppet-languageserver/sidecar_protocol.rb
+++ b/lib/puppet-languageserver/sidecar_protocol.rb
@@ -154,12 +154,15 @@ module PuppetLanguageServer
         attr_accessor :doc
         attr_accessor :arity
         attr_accessor :type
+        # The version of this function, typically 3 or 4.
+        attr_accessor :function_version
 
         def to_h
           super.to_h.merge(
-            'doc'   => doc,
-            'arity' => arity,
-            'type'  => type
+            'doc'              => doc,
+            'arity'            => arity,
+            'type'             => type,
+            'function_version' => function_version
           )
         end
 
@@ -169,6 +172,7 @@ module PuppetLanguageServer
           self.doc = value['doc']
           self.arity = value['arity']
           self.type = value['type'].intern
+          self.function_version = value['function_version']
           self
         end
       end

--- a/lib/puppet_languageserver_sidecar.rb
+++ b/lib/puppet_languageserver_sidecar.rb
@@ -222,8 +222,6 @@ module PuppetLanguageServerSidecar
   def self.inject_workspace_as_module
     return false unless PuppetLanguageServerSidecar::Workspace.has_module_metadata?
 
-    Puppet.settings[:basemodulepath] = Puppet.settings[:basemodulepath] + ';' + PuppetLanguageServerSidecar::Workspace.root_path
-
     %w[puppet_modulepath_monkey_patches].each do |lib|
       begin
         require "puppet-languageserver-sidecar/#{lib}"

--- a/spec/languageserver-sidecar/fixtures/real_agent/cache/lib/puppet/functions/default_pup4_function.rb
+++ b/spec/languageserver-sidecar/fixtures/real_agent/cache/lib/puppet/functions/default_pup4_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API
+# This should be loaded
+Puppet::Functions.create_function(:default_pup4_function) do
+  # @return [Array<String>]
+  def default_pup4_function
+    'default_pup4_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/real_agent/cache/lib/puppet/functions/environment/default_env_pup4_function.rb
+++ b/spec/languageserver-sidecar/fixtures/real_agent/cache/lib/puppet/functions/environment/default_env_pup4_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API
+# This should be loaded in the environment namespace
+Puppet::Functions.create_function(:'environment::default_env_pup4_function') do
+  # @return [Array<String>]
+  def default_env_pup4_function
+    'default_env_pup4_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/real_agent/cache/lib/puppet/functions/modname/default_mod_pup4_function.rb
+++ b/spec/languageserver-sidecar/fixtures/real_agent/cache/lib/puppet/functions/modname/default_mod_pup4_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API
+# This should be loaded in the module called 'modname' namespace
+Puppet::Functions.create_function(:'modname::default_mod_pup4_function') do
+  # @return [Array<String>]
+  def default_mod_pup4_function
+    'default_env_pup4_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/badname/pup4_function.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/badname/pup4_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API in a module
+# This should not be loaded in the environment namespace
+Puppet::Functions.create_function(:'badname::pup4_function') do
+  # @return [Array<String>]
+  def pup4_function
+    'pup4_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/profile/pup4_envprofile_function.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/profile/pup4_envprofile_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API in a module
+# This should be loaded in the module namespace
+Puppet::Functions.create_function(:'profile::pup4_envprofile_function') do
+  # @return [Array<String>]
+  def pup4_envprofile_function
+    'pup4_envprofile_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/pup4_env_badfile.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/pup4_env_badfile.rb
@@ -1,0 +1,10 @@
+require 'a_bad_gem_that_does_not_exist'
+
+# Example function using the Puppet 4 API in a module
+# This should not be loaded
+Puppet::Functions.create_function(:pup4_env_badfile) do
+  # @return [Array<String>]
+  def pup4_env_badfile
+    'pup4_env_badfile result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/pup4_env_badfunction.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/pup4_env_badfunction.rb
@@ -1,0 +1,9 @@
+# Example function using the Puppet 4 API in a module
+# This should be loaded but never actually successfully invoke
+Puppet::Functions.create_function(:pup4_env_badfunction) do
+  # @return [Array<String>]
+  def pup4_env_badfunction
+    require 'a_bad_gem_that_does_not_exist'
+    'pup4_env_badfunction result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/pup4_env_function.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/functions/pup4_env_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API in a module
+# ??? This should be loaded as global namespace function
+Puppet::Functions.create_function(:pup4_env_function) do
+  # @return [Array<String>]
+  def pup4_env_function
+    'pup4_env_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/badname/fixture_pup4_env_function.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/badname/fixture_pup4_env_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API in a module
+# This should not be loaded in the module namespace
+Puppet::Functions.create_function(:'badname::fixture_pup4_badname_function') do
+  # @return [Array<String>]
+  def fixture_pup4_badname_function
+    'fixture_pup4_badname_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/fixture_pup4_badfile.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/fixture_pup4_badfile.rb
@@ -1,0 +1,10 @@
+require 'a_bad_gem_that_does_not_exist'
+
+# Example function using the Puppet 4 API in a module
+# This should not be loaded
+Puppet::Functions.create_function(:fixture_pup4_badfile) do
+  # @return [Array<String>]
+  def fixture_pup4_badfile
+    'fixture_pup4_badfile result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/fixture_pup4_badfunction.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/fixture_pup4_badfunction.rb
@@ -1,0 +1,9 @@
+# Example function using the Puppet 4 API in a module
+# This should be loaded but never actually successfully invoke
+Puppet::Functions.create_function(:fixture_pup4_badfunction) do
+  # @return [Array<String>]
+  def fixture_pup4_badfunction
+    require 'a_bad_gem_that_does_not_exist'
+    'fixture_pup4_badfunction result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/fixture_pup4_function.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/fixture_pup4_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API in a module
+# This should be loaded as global namespace function
+Puppet::Functions.create_function(:fixture_pup4_function) do
+  # @return [Array<String>]
+  def fixture_pup4_function
+    'fixture_pup4_function result'
+  end
+end

--- a/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/valid/fixture_pup4_mod_function.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/valid/fixture_pup4_mod_function.rb
@@ -1,0 +1,8 @@
+# Example function using the Puppet 4 API in a module
+# This should be loaded in the module namespace
+Puppet::Functions.create_function(:'valid::fixture_pup4_mod_function') do
+  # @return [Array<String>]
+  def fixture_pup4_mod_function
+    'fixture_pup4_mod_function result'
+  end
+end

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_puppetstrings/featureflag_puppetstrings_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_puppetstrings/featureflag_puppetstrings_spec.rb
@@ -2,9 +2,12 @@ require 'spec_helper'
 require 'open3'
 require 'tempfile'
 
-describe 'PuppetLanguageServerSidecar' do
+describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings' do
   def run_sidecar(cmd_options)
     cmd_options << '--no-cache'
+
+    # Append the feature flag
+    cmd_options << '--feature-flag=puppetstrings'
 
     # Append the puppet test-fixtures
     cmd_options << '--puppet-settings'

--- a/spec/languageserver/spec_helper.rb
+++ b/spec/languageserver/spec_helper.rb
@@ -70,6 +70,7 @@ def random_sidecar_puppet_function
   result.doc = 'doc' + rand(1000).to_s
   result.arity = rand(1000)
   result.type = ('type' + rand(1000).to_s).intern
+  result.function_version = rand(1) + 3
   result
 end
 

--- a/spec/languageserver/unit/puppet-languageserver/sidecar_protocol_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/sidecar_protocol_spec.rb
@@ -55,7 +55,7 @@ describe 'PuppetLanguageServer::Sidecar::Protocol' do
   basepuppetobject_properties = [:key, :calling_source, :source, :line, :char, :length]
   nodegraph_properties = [:dot_content, :error_content]
   puppetclass_properties = [:doc, :parameters]
-  puppetfunction_properties = [:doc, :arity, :type]
+  puppetfunction_properties = [:doc, :arity, :type, :function_version]
   puppettype_properties = [:doc, :attributes]
   resource_properties = [:manifest]
 


### PR DESCRIPTION
- [x] Need to add caching back.

Fixes #121 

Task 1-3 of the Puppet 4 API Project

### Task 1
Add a Puppet Strings feature flag - As much as possible, all code should be hidden behind this flag

### Task 2
Load Puppet 4 API Functions but present them as Puppet 3 functions in the Sidecar Protocol.  This preserves existing behaviour of the loading, but requires no changes to the language server itself

### Task 3
Use Puppet Strings (YARD) to load Puppet 4 documentation - Puppet 4 API does not use dedicated `doc` parameters, instead all documentation is provided by YARD based comments, interpretted by the Puppet-Strings gem.  Puppet Strings extends YARD to understand Puppet syntax

---

Previously the monkey patch to inject the editor workspace as a module did not
extract the module name correctly. While this was ok for older Puppet 3 API,
the Puppet 4 API namespaces objects based on the module name, so this TODO
item needed to be completed.  Now we extract the module name correctly.

---

he Sidecar will be experimenting with extracting puppet metadata (classes,
functions and types etc.) via the Puppet Strings gem.  This is an experimental
function and is to be hidden behind a feature flag so users can opt in to the
feature if needed.

This commit:
* Adds a feature flag detection method so downstream code can query if certain
  flags are set
* Verifies that the feature flag is valid.  Puppet Strings, for now, is only
  available from the PDK ruby based environment, not the Agent ruby envuronment.
* Duplicates the puppet_helper and puppet_monkey_patches files in prepartion of
  them being modified when the feature flag is set. This allows changes to code
  to be truly isolated depending on the flag status
* Duplicates the integration tests so that behaviour can be verified that is
  has not changed when the flag is set
* Updates the Gemfile to bring in Puppet Strings during development. Note that
  the Puppet Strings gem is NOT vendored, though that may change in the future

---

The Puppet Strings gem uses YARD to parse the relevant files, however this is
not useful for the Sidecar as we need access to the ruby objects, not a markdown
or JSON file being created.  This commit:

* Adds a PuppetStringsHelper which can configure and execute YARD in the same
  way Puppet Strings does and then allow the Sidecar to extract the information
  it needs later.
* Later commits will modify the helper to understand the various metadata the
  Sidecar needs.
* Adds a caching layer to the results of running YARD. This means that if a
  file is queried more than once, YARD will only be executed once as running
  YARD is an expensive exercise.
* Monkey patches YARD to suppress ALL output.  By default the command line
  parameters still emit text of STDOUT, STDERR which breaks the STDIO transport
  for the Sidecar.

---

Currently the Sidecar can only detect and load Puppet 3 API functions.  The
newer Puppet 4 API functions use a different loader and schema, and importantly
have additional properties e.g. Puppet 4 API functions have one or more
signatures, whereas Puppet 3 API functions use arity.

In order to add the Puppet Strings loader, this commit will load Puppet 4 API
functions but present them to the Language Server as if they were Puppet 3.
A later commit will then change this behaviour so that all the metadata for
Puppet 4 API functions will be known by the Language Server, and Puppet 3 API
function metadata will be munged into the 4 API equivalent.

This commit:
* Extends the Sidecar protocol to add a function_version property to the Puppet
  Function schema.  This can be used later by the Language Server to determine
  how to handle the metadata.
* Adds a new method called retrieve_via_puppet_strings to the puppet_helper.
  This method queries the Puppet Loaders (vai Puppet-As-A-Library PAL) for all
  the files for particular puppet objects (functions in this case) and then gets
  the documentation about these files via the Puppet Strings helper
* The PAL files are only available on Puppet Gem 6 and above, so the feature
  flag is modified to only be active on Puppet version 6+
* Adds in a new method called 'discover_paths' on all PAL loaders.  The loaders
  themselves are normally used to load _something_ by name, however the Sidecar
  wants to load EVERYTHING. Generally this information is private to each
  loader. By adding this additional method, we can extract all of the
  discoverable paths, without needing to write our own loaders
* Removes the old function loading and monkey patches

---

This commit adds test fixtures for Puppet 4 API style functions and modifies the
integration tests to expect these new fixtures.