### PR TITLE
(GH-118) Fail gracefully when critical gems cannot load

### DIFF
--- a/lib/puppet-languageserver/json_rpc_handler.rb
+++ b/lib/puppet-languageserver/json_rpc_handler.rb
@@ -278,7 +278,7 @@ module PuppetLanguageServer
       end
 
       def reply_internal_error(message = nil)
-        return nil if @json_rpc_handler.error?
+        return nil if @json_rpc_handler.connection_error?
         @json_rpc_handler.reply_error(@id, CODE_INTERNAL_ERROR, message || MSG_INTERNAL_ERROR)
       end
 

--- a/lib/puppet-languageserver/server_capabilities.rb
+++ b/lib/puppet-languageserver/server_capabilities.rb
@@ -17,5 +17,11 @@ module PuppetLanguageServer
         'workspaceSymbolProvider' => true
       }
     end
+
+    def self.no_capabilities
+      # Any empty hash denotes no capabilities at all
+      {
+      }
+    end
   end
 end


### PR DESCRIPTION
Fixes #118 

Previously the language server would crash/terminate early if a critical gem
like puppet was unavailable.  This can happen when the ruby environment is not
from the Puppet Agent or PDK.  This commit changes the behaviour of the
Language Server to still execute but it a completely disable fashion:

* Detects a failed gem load for critical gems and sets
  PuppetLanguageServer.active? is to false
* When the Language Server is not active, a different Message Router is used
  which effectively warns the user that the server failed to start and that
  all functions are disabled. The server responds to the client with no
  capabilities and the custom getVersion request, is responded to with
  unknown data

No automated tests were added as this is an edge case.  Manual testing was
performed by changing the call `require 'puppet'` to `require 'puppetxxxxx'`
which is enough to trigger a failure.