### PR TITLE
(maint) Refactor in-memory cache objects

### DIFF
--- a/spec/languageserver/unit/puppet-languageserver/puppet_helper/cache_objects_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/puppet_helper/cache_objects_spec.rb
@@ -19,11 +19,11 @@ describe 'PuppetLanguageServer::PuppetHelper' do
     it_should_behave_like 'a base Puppet object'
 
     # No additional methods to test
-    # [:doc].each do |testcase|
-    #   it "instance should respond to #{testcase}" do
-    #     expect(subject).to respond_to(testcase)
-    #   end
-    # end
+    [:doc, :parameters].each do |testcase|
+      it "instance should respond to #{testcase}" do
+        expect(subject).to respond_to(testcase)
+      end
+    end
 
     describe '#from_sidecar!' do
       it 'should populate from a sidecar function object' do


### PR DESCRIPTION
Previously the in-memory cache objects duplicated the object properties of the
Sidecar protocol but this is not necessary.  This commit changes the inmemory
cache object to instead inherits from the sidecar and extends it.  The
from_sidecar! method is modified to dynamically copy the object instead of
hardcoded values.