### PR TITLE
(GH-141) Modify the Puppet Function loading to use all of the new Puppet 4 API features

### DIFF
--- a/lib/puppet-languageserver/manifest/hover_provider.rb
+++ b/lib/puppet-languageserver/manifest/hover_provider.rb
@@ -142,8 +142,7 @@ module PuppetLanguageServer
         func_info = PuppetLanguageServer::PuppetHelper.function(func_name)
         raise "Function #{func_name} does not exist" if func_info.nil?
 
-        # TODO: what about rvalue?
-        content = "**#{func_name}** Function" # TODO: Do I add in the params from the arity number?
+        content = "**#{func_name}** Function"
         content += "\n\n" + func_info.doc unless func_info.doc.nil?
 
         content

--- a/lib/puppet-languageserver/sidecar_protocol.rb
+++ b/lib/puppet-languageserver/sidecar_protocol.rb
@@ -263,12 +263,16 @@ module PuppetLanguageServer
         attr_accessor :name
         attr_accessor :types
         attr_accessor :doc
+        attr_accessor :signature_key_offset # Zero based offset where this parameter exists in the signature key
+        attr_accessor :signature_key_length # The length of text where this parameter exists in the signature key
 
         def to_h
           {
-            'name'  => name,
-            'doc'   => doc,
-            'types' => types
+            'name'                 => name,
+            'doc'                  => doc,
+            'types'                => types,
+            'signature_key_offset' => signature_key_offset,
+            'signature_key_length' => signature_key_length
           }
         end
 
@@ -276,6 +280,8 @@ module PuppetLanguageServer
           self.name = value['name']
           self.doc = value['doc']
           self.types = value['types']
+          self.signature_key_offset = value['signature_key_offset']
+          self.signature_key_length = value['signature_key_length']
           self
         end
       end

--- a/lib/puppet-languageserver/sidecar_protocol.rb
+++ b/lib/puppet-languageserver/sidecar_protocol.rb
@@ -191,17 +191,20 @@ module PuppetLanguageServer
 
       class PuppetFunction < BasePuppetObject
         attr_accessor :doc
-        attr_accessor :arity
-        attr_accessor :type
         # The version of this function, typically 3 or 4.
         attr_accessor :function_version
+        attr_accessor :signatures
+
+        def initialize
+          super
+          self.signatures = PuppetFunctionSignatureList.new
+        end
 
         def to_h
           super.to_h.merge(
             'doc'              => doc,
-            'arity'            => arity,
-            'type'             => type,
-            'function_version' => function_version
+            'function_version' => function_version,
+            'signatures'       => signatures
           )
         end
 
@@ -209,9 +212,8 @@ module PuppetLanguageServer
           super
 
           self.doc = value['doc']
-          self.arity = value['arity']
-          self.type = value['type'].intern
           self.function_version = value['function_version']
+          value['signatures'].each { |sig| signatures << PuppetFunctionSignature.new.from_h!(sig) } unless value['signatures'].nil?
           self
         end
       end
@@ -219,6 +221,68 @@ module PuppetLanguageServer
       class PuppetFunctionList < BasePuppetObjectList
         def child_type
           PuppetFunction
+        end
+      end
+
+      class PuppetFunctionSignature < BaseClass
+        attr_accessor :key
+        attr_accessor :doc
+        attr_accessor :return_types
+        attr_accessor :parameters
+
+        def initialize
+          super
+          self.parameters = PuppetFunctionSignatureParameterList.new
+        end
+
+        def to_h
+          {
+            'key'          => key,
+            'doc'          => doc,
+            'return_types' => return_types,
+            'parameters'   => parameters
+          }
+        end
+
+        def from_h!(value)
+          self.key = value['key']
+          self.doc = value['doc']
+          self.return_types = value['return_types']
+          value['parameters'].each { |param| parameters << PuppetFunctionSignatureParameter.new.from_h!(param) } unless value['parameters'].nil?
+          self
+        end
+      end
+
+      class PuppetFunctionSignatureList < BasePuppetObjectList
+        def child_type
+          PuppetFunctionSignature
+        end
+      end
+
+      class PuppetFunctionSignatureParameter < BaseClass
+        attr_accessor :name
+        attr_accessor :types
+        attr_accessor :doc
+
+        def to_h
+          {
+            'name'  => name,
+            'doc'   => doc,
+            'types' => types
+          }
+        end
+
+        def from_h!(value)
+          self.name = value['name']
+          self.doc = value['doc']
+          self.types = value['types']
+          self
+        end
+      end
+
+      class PuppetFunctionSignatureParameterList < BasePuppetObjectList
+        def child_type
+          PuppetFunctionSignatureParameter
         end
       end
 

--- a/spec/languageserver-sidecar/fixtures/real_agent/cache/.gitignore
+++ b/spec/languageserver-sidecar/fixtures/real_agent/cache/.gitignore
@@ -1,0 +1,8 @@
+# These can be accidentally created during testing/development
+client_data/
+client_yaml/
+clientbucket/
+locales/
+preview/
+reports/
+state/

--- a/spec/languageserver-sidecar/fixtures/real_agent/environments/testfixtures/modules/defaultmodule/functions/puppetfunc.pp
+++ b/spec/languageserver-sidecar/fixtures/real_agent/environments/testfixtures/modules/defaultmodule/functions/puppetfunc.pp
@@ -1,0 +1,13 @@
+# An example puppet function, as opposed to a ruby custom function
+#
+# @example Declaring the class
+#   $test = defaultmodule::puppetfunc('true')
+#
+# @param arg The first parameter for this function.
+function defaultmodule::puppetfunc(Variant[String, Boolean] $arg) >> String {
+  case $arg {
+    false, undef, /(?i:false)/ : { 'Off' }
+    true, /(?i:true)/          : { 'On' }
+    default               : { "$arg" }
+  }
+}

--- a/spec/languageserver-sidecar/fixtures/valid_module_workspace/functions/modulefunc.pp
+++ b/spec/languageserver-sidecar/fixtures/valid_module_workspace/functions/modulefunc.pp
@@ -1,0 +1,13 @@
+# An example puppet function in a module, as opposed to a ruby custom function
+#
+# @example Declaring the class
+#   $test = valid::modulefunc('true')
+#
+# @param p1 The first parameter for this function.
+function valid::modulefunc(Variant[String, Boolean] $p1) >> String {
+  case $p1 {
+    false, undef, /(?i:false)/ : { 'Off' }
+    true, /(?i:true)/          : { 'On' }
+    default               : { "$p1" }
+  }
+}

--- a/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/fixture_pup4_function.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/functions/fixture_pup4_function.rb
@@ -1,8 +1,31 @@
 # Example function using the Puppet 4 API in a module
 # This should be loaded as global namespace function
 Puppet::Functions.create_function(:fixture_pup4_function) do
-  # @return [Array<String>]
-  def fixture_pup4_function
-    'fixture_pup4_function result'
+  dispatch :method1 do
+    param 'String', :a_string
+    optional_block_param :block
+    return_type 'Array<String>'
+  end
+
+  # Does things with numbers
+  # @param an_integer The first number.
+  # @param values_to_average Zero or more additional numbers.
+  # @return [Array] Nothing useful
+  # @example Subtracting two arrays.
+  #   fixture_pup4_function(3, 2, 1) => ['Hello']
+  dispatch :method2 do
+    param 'Integer', :an_integer
+    optional_repeated_param 'Numeric', :values_to_average
+    return_type 'Array<String>'
+  end
+
+  def method1(a_string, &block)
+    ['fixture_pup4_function result']
+  end
+
+  def method2(an_integer, *values_to_average)
+    ['fixture_pup4_function result']
   end
 end
+
+# Note that method1 has no documentation.  This is for testing default documentation

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_puppetstrings/featureflag_puppetstrings_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_puppetstrings/featureflag_puppetstrings_spec.rb
@@ -55,6 +55,7 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings', :if => G
     expect(deserial).to_not contain_child_with_key(:default_pup4_function)
     expect(deserial).to_not contain_child_with_key(:'environment::default_env_pup4_function')
     expect(deserial).to_not contain_child_with_key(:'modname::default_mod_pup4_function')
+    expect(deserial).to_not contain_child_with_key(:'defaultmodule::puppetfunc')
   end
 
   before(:each) do
@@ -160,6 +161,8 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings', :if => G
       expect(deserial).to contain_child_with_key(:'environment::default_env_pup4_function')
       # These are defined in the fixtures/real_agent/cache/lib/puppet/functions/modname (module namespaced function)
       expect(deserial).to contain_child_with_key(:'modname::default_mod_pup4_function')
+      # These are defined in the fixtures/real_agent/environments/testfixtures/modules/defaultmodules/functions/puppetfunc.pp
+      expect(deserial).to contain_child_with_key(:'defaultmodule::puppetfunc')
 
       # Now run using cached information
       expect_populated_cache
@@ -271,6 +274,7 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings', :if => G
         expect(deserial).to contain_child_with_key(:fixture_pup4_function)
         expect(deserial).to contain_child_with_key(:'valid::fixture_pup4_mod_function')
         expect(deserial).to contain_child_with_key(:fixture_pup4_badfunction)
+        expect(deserial).to contain_child_with_key(:'valid::modulefunc')
 
         # Make sure the function has the right properties
         func = child_with_key(deserial, :fixture_function)
@@ -281,6 +285,13 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings', :if => G
         func = child_with_key(deserial, :fixture_pup4_function)
         expect(func.doc).to match(/Example function using the Puppet 4 API in a module/)
         expect(func.source).to match(/valid_module_workspace/)
+
+        # Make sure the function has the right properties
+        func = child_with_key(deserial, :'valid::modulefunc')
+        expect(func.function_version).to eq(4) # Puppet Langauge functions are V4
+        expect(func.doc).to match(/An example puppet function in a module, as opposed to a ruby custom function/)
+        expect(func.source).to match(/valid_module_workspace/)
+        expect(func.signatures.count).to be > 0
       end
     end
 

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_puppetstrings/featureflag_puppetstrings_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_puppetstrings/featureflag_puppetstrings_spec.rb
@@ -274,7 +274,7 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings', :if => G
 
         # Make sure the function has the right properties
         func = child_with_key(deserial, :fixture_function)
-        expect(func.doc).to eq('doc_fixture_function')
+        expect(func.doc).to match(/doc_fixture_function/)
         expect(func.source).to match(/valid_module_workspace/)
 
         # Make sure the function has the right properties
@@ -380,7 +380,7 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings', :if => G
 
         # Make sure the function has the right properties
         func = child_with_key(deserial, :env_function)
-        expect(func.doc).to eq('doc_env_function')
+        expect(func.doc).to match(/doc_env_function/)
         expect(func.source).to match(/valid_environment_workspace/)
 
         # Make sure the function has the right properties

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_puppetstrings/puppet_strings_helper_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_puppetstrings/puppet_strings_helper_spec.rb
@@ -137,10 +137,14 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings' do
         expect(sig_param.name).to eq('a_string')
         expect(sig_param.doc).to eq('')
         expect(sig_param.types).to eq(['String'])
+        expect(sig_param.signature_key_offset).to eq(29)
+        expect(sig_param.signature_key_length).to eq(9)
         sig_param = sig.parameters[1]
         expect(sig_param.name).to eq('&block')
         expect(sig_param.doc).to eq('')
         expect(sig_param.types).to eq(['Optional[Callable]'])
+        expect(sig_param.signature_key_offset).to eq(59)
+        expect(sig_param.signature_key_length).to eq(7)
 
         # Second signature - Full yard documentation
         sig = item.signatures[1]
@@ -153,10 +157,14 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings' do
         expect(sig_param.name).to eq('an_integer')
         expect(sig_param.doc).to eq('The first number.')
         expect(sig_param.types).to eq(['Integer'])
+        expect(sig_param.signature_key_offset).to eq(30)
+        expect(sig_param.signature_key_length).to eq(11)
         sig_param = sig.parameters[1]
         expect(sig_param.name).to eq('*values_to_average')
         expect(sig_param.doc).to eq('Zero or more additional numbers.')
         expect(sig_param.types).to eq(['Optional[Numeric]'])
+        expect(sig_param.signature_key_offset).to eq(61)
+        expect(sig_param.signature_key_length).to eq(19)
       end
     end
 
@@ -190,6 +198,8 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings' do
         expect(sig_param.name).to eq('p1')
         expect(sig_param.doc).to eq('The first parameter for this function.')
         expect(sig_param.types).to eq(['Variant[String, Boolean]'])
+        expect(sig_param.signature_key_offset).to eq(43)
+        expect(sig_param.signature_key_length).to eq(3)
       end
     end
 

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_puppetstrings/puppet_strings_helper_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_puppetstrings/puppet_strings_helper_spec.rb
@@ -1,0 +1,230 @@
+require 'spec_helper'
+
+describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings' do
+  before(:each) do
+    skip('Puppet Strings is not available') if Gem::Specification.select { |item| item.name.casecmp('puppet-strings') }.count.zero?
+    skip('Puppet 6.0.0 or above is required') unless Gem::Version.new(Puppet.version) >= Gem::Version.new('6.0.0')
+
+    # Load files based on feature flags
+    ['puppet_strings_helper', 'puppet_strings_monkey_patches'].each do |lib|
+      require "puppet-languageserver-sidecar/#{lib}"
+    end
+  end
+
+  describe 'PuppetLanguageServerSidecar::PuppetStringsHelper' do
+    let(:subject) { PuppetLanguageServerSidecar::PuppetStringsHelper::Helper.new }
+    let(:cache) { nil }
+
+    # Classes
+    context 'Given a Puppet Class' do
+      let(:fixture_filepath) { File.join($fixtures_dir, 'real_agent', 'environments', 'testfixtures', 'modules', 'defaultmodule', 'manifests', 'init.pp' ) }
+
+      it 'should parse the file metadata correctly' do
+        result = subject.file_documentation(fixture_filepath, cache)
+
+        # There is only one class in the test fixture file
+        expect(result.classes.count).to eq(1)
+        item = result.classes[0]
+
+        # Check base methods
+        expect(item.key).to eq('defaultmodule')
+        expect(item.line).to eq(8)
+        expect(item.char).to be_nil
+        expect(item.length).to be_nil
+        expect(item.source).to eq(fixture_filepath)
+        # Check class specific methods
+        expect(item.doc).to match(/This is an example of how to document a Puppet class/)
+        # Check the class parameters
+        expect(item.parameters.count).to eq(2)
+        param = item.parameters['first']
+        expect(param[:doc]).to eq('The first parameter for this class.')
+        expect(param[:type]).to eq('String')
+        param = item.parameters['second']
+        expect(param[:doc]).to eq('The second parameter for this class.')
+        expect(param[:type]).to eq('Integer')
+      end
+    end
+
+    context 'Given a Puppet Defined Type' do
+      let(:fixture_filepath) { File.join($fixtures_dir, 'real_agent', 'environments', 'testfixtures', 'modules', 'defaultmodule', 'manifests', 'definedtype.pp' ) }
+
+      it 'should parse the file metadata correctly' do
+        result = subject.file_documentation(fixture_filepath, cache)
+
+        # There is only one class in the test fixture file
+        expect(result.classes.count).to eq(1)
+        item = result.classes[0]
+
+        # Check base methods
+        expect(item.key).to eq('defaultdefinedtype')
+        expect(item.line).to eq(6)
+        expect(item.char).to be_nil
+        expect(item.length).to be_nil
+        expect(item.source).to eq(fixture_filepath)
+        # Check class specific methods
+        expect(item.doc).to match(/This is an example of how to document a defined type./)
+        # Check the class parameters
+        expect(item.parameters.count).to eq(2)
+        param = item.parameters['ensure']
+        expect(param[:doc]).to eq('Ensure parameter documentation.')
+        expect(param[:type]).to eq('Any')
+        param = item.parameters['param2']
+        expect(param[:doc]).to eq('param2 documentation.')
+        expect(param[:type]).to eq('String')
+      end
+    end
+
+    # Functions
+    context 'Given a Ruby Puppet 3 API Function' do
+      let(:fixture_filepath) { File.join($fixtures_dir, 'real_agent', 'cache', 'lib', 'puppet', 'parser', 'functions', 'default_cache_function.rb' ) }
+
+      it 'should parse the file metadata correctly' do
+        result = subject.file_documentation(fixture_filepath, cache)
+
+        # There is only one function in the test fixture file
+        expect(result.functions.count).to eq(1)
+        item = result.functions[0]
+
+        # Check base methods
+        expect(item.key).to eq('default_cache_function')
+        expect(item.line).to eq(2)
+        expect(item.char).to eq(12)
+        expect(item.length).to eq(23)
+        expect(item.source).to eq(fixture_filepath)
+        # Check function specific methods
+        expect(item.doc).to match(/A function that should appear in the list of default functions/)
+        expect(item.function_version).to eq(3)
+        # Check the function signatures
+        expect(item.signatures.count).to eq(1)
+        sig = item.signatures[0]
+        expect(sig.doc).to match(/A function that should appear in the list of default functions/)
+        expect(sig.key).to eq('default_cache_function()')
+        expect(sig.return_types).to eq(['Any'])
+        # Check the function signature parameters
+        expect(sig.parameters.count).to eq(0)
+      end
+    end
+
+    context 'Given a Ruby Puppet 4 API Function' do
+      let(:fixture_filepath) { File.join($fixtures_dir, 'valid_module_workspace', 'lib', 'puppet', 'functions', 'fixture_pup4_function.rb') }
+
+      it 'should parse the file metadata correctly' do
+        result = subject.file_documentation(fixture_filepath, cache)
+
+        # There is only one function in the test fixture file
+        expect(result.functions.count).to eq(1)
+        item = result.functions[0]
+        # Check base methods
+        expect(item.key).to eq('fixture_pup4_function')
+        expect(item.line).to eq(3)
+        expect(item.char).to eq(34)
+        expect(item.length).to eq(22)
+        expect(item.source).to eq(fixture_filepath)
+        # Check function specific methods
+        expect(item.doc).to match(/Example function using the Puppet 4 API in a module/)
+        expect(item.function_version).to eq(4)
+        # Check the function signatures
+        expect(item.signatures.count).to eq(2)
+
+        # First signature - No yard documentation
+        sig = item.signatures[0]
+        expect(sig.doc).to eq('')
+        expect(sig.key).to eq('fixture_pup4_function(String $a_string, Optional[Callable] &$block)')
+        expect(sig.return_types).to eq(['Array<String>'])
+        # Check the function signature parameters
+        expect(sig.parameters.count).to eq(2)
+        sig_param = sig.parameters[0]
+        expect(sig_param.name).to eq('a_string')
+        expect(sig_param.doc).to eq('')
+        expect(sig_param.types).to eq(['String'])
+        sig_param = sig.parameters[1]
+        expect(sig_param.name).to eq('&block')
+        expect(sig_param.doc).to eq('')
+        expect(sig_param.types).to eq(['Optional[Callable]'])
+
+        # Second signature - Full yard documentation
+        sig = item.signatures[1]
+        expect(sig.doc).to eq('Does things with numbers')
+        expect(sig.key).to eq('fixture_pup4_function(Integer $an_integer, Optional[Numeric] *$values_to_average)')
+        expect(sig.return_types).to eq(['Array<String>'])
+        # Check the function signature parameters
+        expect(sig.parameters.count).to eq(2)
+        sig_param = sig.parameters[0]
+        expect(sig_param.name).to eq('an_integer')
+        expect(sig_param.doc).to eq('The first number.')
+        expect(sig_param.types).to eq(['Integer'])
+        sig_param = sig.parameters[1]
+        expect(sig_param.name).to eq('*values_to_average')
+        expect(sig_param.doc).to eq('Zero or more additional numbers.')
+        expect(sig_param.types).to eq(['Optional[Numeric]'])
+      end
+    end
+
+    context 'Given a Puppet Language Function' do
+      let(:fixture_filepath) { File.join($fixtures_dir, 'valid_module_workspace', 'functions', 'modulefunc.pp') }
+
+      it 'should parse the file metadata correctly' do
+        result = subject.file_documentation(fixture_filepath, cache)
+
+        # There is only one function in the test fixture file
+        expect(result.functions.count).to eq(1)
+        item = result.functions[0]
+        # Check base methods
+        expect(item.key).to eq('valid::modulefunc')
+        expect(item.line).to eq(7)
+        expect(item.char).to be_nil
+        expect(item.length).to be_nil
+        expect(item.source).to eq(fixture_filepath)
+        # Check function specific methods
+        expect(item.doc).to match(/An example puppet function in a module, as opposed to a ruby custom function/)
+        expect(item.function_version).to eq(4)
+        # Check the function signatures
+        expect(item.signatures.count).to eq(1)
+        sig = item.signatures[0]
+        expect(sig.doc).to match(/An example puppet function in a module, as opposed to a ruby custom function/)
+        expect(sig.key).to eq('valid::modulefunc(Variant[String, Boolean] $p1)')
+        expect(sig.return_types).to eq(['String'])
+        # Check the function signature parameters
+        expect(sig.parameters.count).to eq(1)
+        sig_param = sig.parameters[0]
+        expect(sig_param.name).to eq('p1')
+        expect(sig_param.doc).to eq('The first parameter for this function.')
+        expect(sig_param.types).to eq(['Variant[String, Boolean]'])
+      end
+    end
+
+    # Types
+    context 'Given a Puppet Custom Type' do
+      let(:fixture_filepath) { File.join($fixtures_dir, 'real_agent', 'cache', 'lib', 'puppet', 'type', 'default_type.rb' ) }
+
+      it 'should parse the file metadata correctly' do
+        result = subject.file_documentation(fixture_filepath, cache)
+
+        # There is only one type in the test fixture file
+        expect(result.types.count).to eq(1)
+        item = result.types[0]
+
+        # Check base methods
+        expect(item.key).to eq('default_type')
+        expect(item.line).to eq(1)
+        expect(item.char).to be_nil
+        expect(item.length).to be_nil
+        expect(item.source).to eq(fixture_filepath)
+        # Check type specific methods
+        expect(item.doc).to match(/Sets the global defaults for all printers on the system./)
+        # Check the type attributes
+        expect(item.attributes.count).to eq(2)
+        param = item.attributes['ensure']
+        expect(param[:doc]).to eq('The basic property that the resource should be in.')
+        expect(param[:type]).to eq(:property)
+        expect(param[:isnamevar?]).to be_nil
+        expect(param[:required?]).to be_nil
+        param = item.attributes['name']
+        expect(param[:doc]).to eq('The name of the default_type.')
+        expect(param[:type]).to eq(:param)
+        expect(param[:isnamevar?]).to eq(true)
+        expect(param[:required?]).to be_nil
+      end
+    end
+  end
+end

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/puppet-languageserver-sidecar_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/puppet-languageserver-sidecar_spec.rb
@@ -156,7 +156,7 @@ describe 'PuppetLanguageServerSidecar' do
 
         # Make sure the function has the right properties
         func = child_with_key(deserial, :fixture_function)
-        expect(func.doc).to eq('doc_fixture_function')
+        expect(func.doc).to match(/doc_fixture_function/)
         expect(func.source).to match(/valid_module_workspace/)
       end
     end
@@ -247,7 +247,7 @@ describe 'PuppetLanguageServerSidecar' do
 
         # Make sure the function has the right properties
         func = child_with_key(deserial, :env_function)
-        expect(func.doc).to eq('doc_env_function')
+        expect(func.doc).to match(/doc_env_function/)
         expect(func.source).to match(/valid_environment_workspace/)
       end
     end

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/puppet_parser_helper_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/puppet_parser_helper_spec.rb
@@ -4,12 +4,26 @@ describe 'PuppetLanguageServerSidecar::PuppetParserHelper' do
   let (:subject) { PuppetLanguageServerSidecar::PuppetParserHelper }
 
   describe '#compile_node_graph' do
+    def tasks_supported?
+      Gem::Version.new(Puppet.version) >= Gem::Version.new('5.4.0')
+    end
+
+    before(:each) do
+      @original_taskmode = Puppet[:tasks] if tasks_supported?
+      Puppet[:tasks] = false if tasks_supported?
+    end
+
+    after(:each) do
+      Puppet[:tasks] = @original_taskmode if tasks_supported?
+    end
+
     context 'a valid manifest' do
       let(:manifest) { "user { 'test':\nensure => present\n}\n "}
 
       it 'should compile succesfully' do
         result = subject.compile_node_graph(manifest)
         expect(result).to_not be_nil
+
         # Make sure it's a DOT graph file
         expect(result.dot_content).to match(/digraph/)
         # Make sure the resource is there

--- a/spec/languageserver-sidecar/unit/puppet-languageserver-sidecar/sidecar_protocol_extensions_spec.rb
+++ b/spec/languageserver-sidecar/unit/puppet-languageserver-sidecar/sidecar_protocol_extensions_spec.rb
@@ -84,15 +84,19 @@ describe 'PuppetLanguageServerSidecar::Protocol' do
     describe '.from_puppet' do
       it 'should populate from a Puppet function object' do
         result = subject_klass.from_puppet(puppet_funcname, puppet_func)
+        # This method is only called for V3 API functions.
+        # Therefore we need to assert the V3 function into V4 metadata
 
-        expect(result.doc).to eq(puppet_func[:doc])
-        expect(result.arity).to eq(puppet_func[:arity])
-        expect(result.type).to eq(puppet_func[:type])
+        expect(result.doc).to match(puppet_func[:doc])
+        expect(result.function_version).to eq(3)
+        expect(result.signatures.count).to eq(1)
+        expect(result.signatures[0].doc).to match(puppet_func[:doc])
+        expect(result.signatures[0].key).to eq("#{puppet_funcname}()")
       end
     end
 
     describe '#from_json' do
-      [:doc, :arity, :type].each do |testcase|
+      [:doc, :function_version, :signatures].each do |testcase|
         it "should deserialize a serialized #{testcase} value" do
           serial = subject_klass.from_puppet(puppet_funcname, puppet_func)
           deserial = subject_klass.new.from_json!(serial.to_json)

--- a/spec/languageserver/integration/puppet-languageserver/manifest/completion_provider_spec.rb
+++ b/spec/languageserver/integration/puppet-languageserver/manifest/completion_provider_spec.rb
@@ -458,10 +458,10 @@ EOT
           expect(result.documentation).to match(/.+/)
         end
 
-        it 'should return a text snippet' do
+        it 'should return plain text' do
           result = subject.resolve(@resolve_request)
           expect(result.insertText).to match(/.+/)
-          expect(result.insertTextFormat).to eq(LSP::InsertTextFormat::SNIPPET)
+          expect(result.insertTextFormat).to eq(LSP::InsertTextFormat::PLAINTEXT)
         end
       end
     end

--- a/spec/languageserver/spec_helper.rb
+++ b/spec/languageserver/spec_helper.rb
@@ -68,9 +68,29 @@ end
 def random_sidecar_puppet_function
   result = add_random_basepuppetobject_values!(PuppetLanguageServer::Sidecar::Protocol::PuppetFunction.new())
   result.doc = 'doc' + rand(1000).to_s
-  result.arity = rand(1000)
-  result.type = ('type' + rand(1000).to_s).intern
   result.function_version = rand(1) + 3
+  result.signatures << random_sidecar_puppet_function_signature
+  result.signatures << random_sidecar_puppet_function_signature
+  result.signatures << random_sidecar_puppet_function_signature
+  result
+end
+
+def random_sidecar_puppet_function_signature
+  result = PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionSignature.new
+  result.key = 'key' + rand(1000).to_s + '(a,b,c)'
+  result.doc = 'doc' + rand(1000).to_s
+  result.return_types = [rand(1000).to_s, rand(1000).to_s, rand(1000).to_s]
+  result.parameters << random_sidecar_puppet_function_signature_parameter
+  result.parameters << random_sidecar_puppet_function_signature_parameter
+  result.parameters << random_sidecar_puppet_function_signature_parameter
+  result
+end
+
+def random_sidecar_puppet_function_signature_parameter
+  result = PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionSignatureParameter.new
+  result.name = 'param' + rand(1000).to_s
+  result.types = [rand(1000).to_s, rand(1000).to_s]
+  result.doc = result.name + ' documentation'
   result
 end
 

--- a/spec/languageserver/spec_helper.rb
+++ b/spec/languageserver/spec_helper.rb
@@ -91,6 +91,8 @@ def random_sidecar_puppet_function_signature_parameter
   result.name = 'param' + rand(1000).to_s
   result.types = [rand(1000).to_s, rand(1000).to_s]
   result.doc = result.name + ' documentation'
+  result.signature_key_offset = rand(1000)
+  result.signature_key_length = rand(1000)
   result
 end
 

--- a/spec/languageserver/unit/puppet-languageserver/puppet_helper/cache_objects_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/puppet_helper/cache_objects_spec.rb
@@ -46,7 +46,7 @@ describe 'PuppetLanguageServer::PuppetHelper' do
 
     it_should_behave_like 'a base Puppet object'
 
-    [:doc, :arity, :type].each do |testcase|
+    [:doc, :function_version, :signatures].each do |testcase|
       it "instance should respond to #{testcase}" do
         expect(subject).to respond_to(testcase)
       end
@@ -63,8 +63,8 @@ describe 'PuppetLanguageServer::PuppetHelper' do
         expect(subject.char).to eq(sidecar_puppet_func.char)
         expect(subject.length).to eq(sidecar_puppet_func.length)
         expect(subject.doc).to eq(sidecar_puppet_func.doc)
-        expect(subject.arity).to eq(sidecar_puppet_func.arity)
-        expect(subject.type).to eq(sidecar_puppet_func.type)
+        expect(subject.function_version).to eq(sidecar_puppet_func.function_version)
+        expect(subject.signatures).to eq(sidecar_puppet_func.signatures)
       end
     end
   end

--- a/spec/languageserver/unit/puppet-languageserver/sidecar_protocol_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/sidecar_protocol_spec.rb
@@ -55,7 +55,9 @@ describe 'PuppetLanguageServer::Sidecar::Protocol' do
   basepuppetobject_properties = [:key, :calling_source, :source, :line, :char, :length]
   nodegraph_properties = [:dot_content, :error_content]
   puppetclass_properties = [:doc, :parameters]
-  puppetfunction_properties = [:doc, :arity, :type, :function_version]
+  puppetfunction_properties = [:doc, :function_version, :signatures]
+  puppetfunctionsignature_properties = [:key, :doc, :return_types, :parameters]
+  puppetfunctionsignatureparameter_properties = [:name, :types, :doc]
   puppettype_properties = [:doc, :attributes]
   resource_properties = [:manifest]
 
@@ -190,8 +192,11 @@ describe 'PuppetLanguageServer::Sidecar::Protocol' do
     let(:subject) {
       value = subject_klass.new
       value.doc = 'doc'
-      value.arity = 'arity'
-      value.type = :type
+      value.function_version = 4
+      value.signatures = PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionSignatureList.new
+      value.signatures << random_sidecar_puppet_function_signature
+      value.signatures << random_sidecar_puppet_function_signature
+      value.signatures << random_sidecar_puppet_function_signature
       add_default_basepuppetobject_values!(value)
     }
 
@@ -231,6 +236,102 @@ describe 'PuppetLanguageServer::Sidecar::Protocol' do
 
     it "instance should have a childtype of PuppetFunction" do
       expect(subject.child_type).to eq(PuppetLanguageServer::Sidecar::Protocol::PuppetFunction)
+    end
+  end
+
+  describe 'PuppetFunctionSignature' do
+    let(:subject_klass) { PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionSignature }
+    let(:subject) {
+      value = subject_klass.new
+      value.key = 'something(Any a, String[1,1] b'
+      value.doc = 'doc'
+      value.return_types = ['Any', 'Undef']
+      value.parameters << random_sidecar_puppet_function_signature_parameter
+      value.parameters << random_sidecar_puppet_function_signature_parameter
+      value
+    }
+
+    puppetfunctionsignature_properties.each do |testcase|
+      it "instance should respond to #{testcase}" do
+        expect(subject).to respond_to(testcase)
+      end
+    end
+
+    describe '#from_json!' do
+      (puppetfunctionsignature_properties).each do |testcase|
+        it "should deserialize a serialized #{testcase} value" do
+          serial = subject.to_json
+          deserial = subject_klass.new.from_json!(serial)
+
+          expect(deserial.send(testcase)).to eq(subject.send(testcase))
+        end
+      end
+    end
+  end
+
+  describe 'PuppetFunctionSignatureList' do
+    let(:subject_klass) { PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionSignatureList }
+    let(:subject) {
+      value = subject_klass.new
+      value << random_sidecar_puppet_function_signature
+      value << random_sidecar_puppet_function_signature
+      value << random_sidecar_puppet_function_signature
+      value
+    }
+
+    it_should_behave_like 'a base Sidecar Protocol Puppet object list'
+
+    it_should_behave_like 'a serializable object list'
+
+    it "instance should have a childtype of PuppetFunctionSignature" do
+      expect(subject.child_type).to eq(PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionSignature)
+    end
+  end
+
+  describe 'PuppetFunctionSignatureParameter' do
+    let(:subject_klass) { PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionSignatureParameter }
+    let(:subject) {
+      value = subject_klass.new
+      value.name = 'param1'
+      value.types = ['Undef']
+      value.doc = 'doc'
+      value
+    }
+
+    puppetfunctionsignatureparameter_properties.each do |testcase|
+      it "instance should respond to #{testcase}" do
+        expect(subject).to respond_to(testcase)
+      end
+    end
+
+    describe '#from_json!' do
+      (puppetfunctionsignatureparameter_properties).each do |testcase|
+        it "should deserialize a serialized #{testcase} value" do
+          serial = subject.to_json
+          deserial = subject_klass.new.from_json!(serial)
+
+          expect(deserial.send(testcase)).to eq(subject.send(testcase))
+        end
+      end
+    end
+  end
+
+  describe 'PuppetFunctionSignatureParameterList' do
+    let(:subject_klass) { PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionSignatureParameterList }
+    let(:subject) {
+      value = subject_klass.new
+      value << random_sidecar_puppet_function_signature_parameter
+      value << random_sidecar_puppet_function_signature_parameter
+      value << random_sidecar_puppet_function_signature_parameter
+      value
+    }
+
+    it_should_behave_like 'a base Sidecar Protocol Puppet object list'
+
+    it_should_behave_like 'a serializable object list'
+
+    it "instance should have a childtype of PuppetFunctionSignatureParameter" do
+      expect(subject.child_type).to eq(PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionSignatureParameter)
     end
   end
 

--- a/spec/languageserver/unit/puppet-languageserver/sidecar_protocol_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/sidecar_protocol_spec.rb
@@ -57,7 +57,7 @@ describe 'PuppetLanguageServer::Sidecar::Protocol' do
   puppetclass_properties = [:doc, :parameters]
   puppetfunction_properties = [:doc, :function_version, :signatures]
   puppetfunctionsignature_properties = [:key, :doc, :return_types, :parameters]
-  puppetfunctionsignatureparameter_properties = [:name, :types, :doc]
+  puppetfunctionsignatureparameter_properties = [:name, :types, :doc, :signature_key_offset, :signature_key_length ]
   puppettype_properties = [:doc, :attributes]
   resource_properties = [:manifest]
 
@@ -295,6 +295,8 @@ describe 'PuppetLanguageServer::Sidecar::Protocol' do
       value.name = 'param1'
       value.types = ['Undef']
       value.doc = 'doc'
+      value.signature_key_offset = nil
+      value.signature_key_length = 5
       value
     }
 


### PR DESCRIPTION
~~Builds on #140~~

Fixes #141

- [x] Remove all TODOs
- [x] What about puppet language functions?

---

Previously the Sidecar Protocol had the serialisation methods on the
BasePuppetObject however this meant anything that wanted to use the
serialisation methods also inherited the parameters like key and calling_source.

This commit:
* Moves the serialisation methods (to_json, from_json!) to BaseClass which
  BasePuppetObject now inherits from
* Adds equality methods on the BaseClass to make it possible to compare
  Sidecar objects correctly.  This is mainly required in spec tests to test for
  equality (either == or eql?)
* Adds a hash method to generate the hash number required when Sidecar objects
  are put into hashtables

---

Previously the Puppet Function information retrieved over the Sidecar Protocol
only supported the older V3 Function API.  This commit updates the Protocol to
now be able to transmit V4 function information.  V3 information is expected to
be adapted into its equivalent in V4.

This commit:
* Removes the deprecated arity and type methods and adds function_version and
  signatures.  Where signatures are the function method signatures expressed as
  a PuppetFunctionSignatureList object
* Adds a PuppetFunctionSignature and PuppetFunctionSignatureList object which
  captures all of the properties of Puppet Function V4 API method signature.
  The PuppetFunctionSignatureList object is a "typed" array of
  PuppetFunctionSignature objects
* Adds a PuppetFunctionSignatureParameter and
  PuppetFunctionSignatureParameterList object which captures all of the
  properties of Puppet Function V4 API method signature parameter. The
  PuppetFunctionSignatureParameterList object is a "typed" array of
  PuppetFunctionSignatureParameter objects
* Updates the spec_helper to be able to create mock objects for functions,
  function signatures and function signature parameters
* Updates the sidecar protocol tests for the modified parameters and newly added
  classes
* Updates the in-memory cache object tests for the modified parameters of a
  Function.

---

Previously a Puppet Strings Helper was added however there no tests for the
metadata extraction.  This commit:

* Adds tests to ensure that YARD/Puppet Strings extracts the metadata correctly
* Converts the Strings Helper module into a class to make it easier to test
* Updates the Puppet 4 function fixture to be a more complete example

---

When Puppet Strings extracts the parameter name it differs from how it appears
in the signature key. This makes it hard for clients to determine where in the
signature, the parameter actually is. This commit:

* Updates the Sidecar Protocol and adds two new methods for the
  PuppetFunctionSignatureParameter class; signature_key_offset and
  signature_key_length.  These values will store where in the signature key
  a parameter exists
* Updates the protocol tests and spec helper for the new methods
* Updates the Puppet Strings Helper to detect and populate the offset and length
  values for each parameter in a signature
* Updates the Puppet Strings Helper tests to assert these values are correct for
  bare parameter names, blocks and splattable arguments.

---

Previously the Sidecar could only emit information in function V3 API format.
Now that the Sidecar Protocol has been changed to emit V4 information, this
commit updates the Sidecar to extact the V4 information.

This commit:
* Updates the sidecar_protocol_extensions for the Puppet Function object to
  adapt the V3 function information into the V4 version
* Updates the tests for the sidecar_protocol_extensions for the new parameters
  for the V4 API functions
* Updates the Puppet Strings Helper to extract the required information from
  YARN in order to populate the V4 API function metadata.  In particular the
  concepts of function type and arity no longer apply, and have been replaced
  using Function Signatures.

---

Now that the Sidecar and the Sidecar Protocol have been modified to emit V4
API function metadata the completion and hover providers need to be modified
to use it.  This commit:

* Because the concept of Function Type no longer exists (rvalue vs statement)
  all functions need to be returned when in the root of a document.  Therefore
  the all_statement_functions method is changed into all_functions
* The completion resolver is modified to only emit completion information if the
  function actually has a signature (all functions should have at least one
  sig). The resulting resolution now returns the function documentation and
  function signatures in separate fields in the response
* The insertion text for the completion item now just emits the function with
  empty parentheses. This should trigger the Signature Helper, which will be
  implemented in later commits
* The hover provider is modified to remove a todo item because arity no longer
  exists