### PR TITLE
 (GH-128) Detect Puppet Plan files correctly

### DIFF
--- a/lib/puppet-languageserver/document_store.rb
+++ b/lib/puppet-languageserver/document_store.rb
@@ -59,7 +59,7 @@ module PuppetLanguageServer
     # "Given the full path to the .pp file, if it contains a directory called plans, AND that plans is not a sub-directory of manifests, then it is a plan file"
     #
     # See https://github.com/lingua-pupuli/puppet-editor-services/issues/129 for the full discussion
-    def self.module_plan_file?(uri)
+    def self.plan_file?(uri)
       uri_path = PuppetLanguageServer::UriHelper.uri_path(uri)
       return false if uri_path.nil?
       if windows?

--- a/lib/puppet-languageserver/document_store.rb
+++ b/lib/puppet-languageserver/document_store.rb
@@ -54,13 +54,25 @@ module PuppetLanguageServer
       end
     end
 
-    # Plan files https://puppet.com/docs/bolt/1.x/writing_plans.html#concept-4485
-    # exist in modules (requires metadata.json) and are in the `/plans` directory
+    # Plan files https://puppet.com/docs/bolt/1.x/writing_plans.html#concept-4485 can exist in many places
+    # The current best detection method is as follows:
+    # "Given the full path to the .pp file, if it contains a directory called plans, AND that plans is not a sub-directory of manifests, then it is a plan file"
+    #
+    # See https://github.com/lingua-pupuli/puppet-editor-services/issues/129 for the full discussion
     def self.module_plan_file?(uri)
-      return false unless store_has_module_metadata?
-      relative_path = PuppetLanguageServer::UriHelper.relative_uri_path(PuppetLanguageServer::UriHelper.build_file_uri(store_root_path), uri, !windows?)
-      return false if relative_path.nil?
-      relative_path.start_with?('/plans/')
+      uri_path = PuppetLanguageServer::UriHelper.uri_path(uri)
+      return false if uri_path.nil?
+      if windows?
+        plans_index = uri_path.upcase.index('/PLANS/')
+        manifests_index = uri_path.upcase.index('/MANIFESTS/')
+      else
+        plans_index = uri_path.index('/plans/')
+        manifests_index = uri_path.index('/manifests/')
+      end
+      return false if plans_index.nil?
+      return true if manifests_index.nil?
+
+      plans_index < manifests_index
     end
 
     # Workspace management

--- a/lib/puppet-languageserver/message_router.rb
+++ b/lib/puppet-languageserver/message_router.rb
@@ -110,7 +110,7 @@ module PuppetLanguageServer
         begin
           case documents.document_type(file_uri)
           when :manifest
-            request.reply_result(PuppetLanguageServer::Manifest::CompletionProvider.complete(content, line_num, char_num, :tasks_mode => PuppetLanguageServer::DocumentStore.module_plan_file?(file_uri)))
+            request.reply_result(PuppetLanguageServer::Manifest::CompletionProvider.complete(content, line_num, char_num, :tasks_mode => PuppetLanguageServer::DocumentStore.plan_file?(file_uri)))
           else
             raise "Unable to provide completion on #{file_uri}"
           end
@@ -138,7 +138,7 @@ module PuppetLanguageServer
         begin
           case documents.document_type(file_uri)
           when :manifest
-            request.reply_result(PuppetLanguageServer::Manifest::HoverProvider.resolve(content, line_num, char_num, :tasks_mode => PuppetLanguageServer::DocumentStore.module_plan_file?(file_uri)))
+            request.reply_result(PuppetLanguageServer::Manifest::HoverProvider.resolve(content, line_num, char_num, :tasks_mode => PuppetLanguageServer::DocumentStore.plan_file?(file_uri)))
           else
             raise "Unable to provide hover on #{file_uri}"
           end
@@ -155,7 +155,7 @@ module PuppetLanguageServer
         begin
           case documents.document_type(file_uri)
           when :manifest
-            request.reply_result(PuppetLanguageServer::Manifest::DefinitionProvider.find_definition(content, line_num, char_num, :tasks_mode => PuppetLanguageServer::DocumentStore.module_plan_file?(file_uri)))
+            request.reply_result(PuppetLanguageServer::Manifest::DefinitionProvider.find_definition(content, line_num, char_num, :tasks_mode => PuppetLanguageServer::DocumentStore.plan_file?(file_uri)))
           else
             raise "Unable to provide definition on #{file_uri}"
           end
@@ -170,7 +170,7 @@ module PuppetLanguageServer
         begin
           case documents.document_type(file_uri)
           when :manifest
-            request.reply_result(PuppetLanguageServer::Manifest::DocumentSymbolProvider.extract_document_symbols(content, :tasks_mode => PuppetLanguageServer::DocumentStore.module_plan_file?(file_uri)))
+            request.reply_result(PuppetLanguageServer::Manifest::DocumentSymbolProvider.extract_document_symbols(content, :tasks_mode => PuppetLanguageServer::DocumentStore.plan_file?(file_uri)))
           else
             raise "Unable to provide definition on #{file_uri}"
           end

--- a/lib/puppet-languageserver/uri_helper.rb
+++ b/lib/puppet-languageserver/uri_helper.rb
@@ -9,6 +9,15 @@ module PuppetLanguageServer
       'file://' + Puppet::Util.uri_encode(path.start_with?('/') ? path : '/' + path)
     end
 
+    def self.uri_path(uri)
+      actual_uri = URI(uri)
+
+      # CGI.unescape doesn't handle space rules properly in uri paths
+      # URI.unescape does, but returns strings in their original encoding
+      # Mostly safe here as we're only worried about file based URIs
+      URI.unescape(actual_uri.path) # rubocop:disable Lint/UriEscapeUnescape
+    end
+
     # Compares two URIs and returns the relative path
     #
     # @param root_uri [String] The root URI to compare to

--- a/lib/puppet-languageserver/validation_queue.rb
+++ b/lib/puppet-languageserver/validation_queue.rb
@@ -84,7 +84,7 @@ module PuppetLanguageServer
       # Perform validation
       case document_type
       when :manifest
-        PuppetLanguageServer::Manifest::ValidationProvider.validate(content, :tasks_mode => PuppetLanguageServer::DocumentStore.module_plan_file?(document_uri))
+        PuppetLanguageServer::Manifest::ValidationProvider.validate(content, :tasks_mode => PuppetLanguageServer::DocumentStore.plan_file?(document_uri))
       when :epp
         PuppetLanguageServer::Epp::ValidationProvider.validate(content)
       when :puppetfile

--- a/spec/languageserver/integration/puppet-languageserver/document_store_spec.rb
+++ b/spec/languageserver/integration/puppet-languageserver/document_store_spec.rb
@@ -165,31 +165,31 @@ describe 'PuppetLanguageServer::DocumentStore' do
     ['/plans/test.pp', '/plans/a/b/c/something.pp'].each do |testcase|
       it "should detect '#{testcase}' as a plan file" do
         file_uri = PuppetLanguageServer::UriHelper.build_file_uri(subject.store_root_path) + testcase
-        expect(subject.module_plan_file?(file_uri)).to be(true)
+        expect(subject.plan_file?(file_uri)).to be(true)
       end
     end
 
     ['/plan__s/test.pp', 'plans/something.txt', '/plantest.pp', ].each do |testcase|
       it "should not detect '#{testcase}' as a plan file" do
         file_uri = PuppetLanguageServer::UriHelper.build_file_uri(subject.store_root_path) + testcase
-        expect(subject.module_plan_file?(file_uri)).to be(false)
+        expect(subject.plan_file?(file_uri)).to be(false)
       end
     end
 
     it 'should detect plan files as case insensitive on Windows' do
       allow(subject).to receive(:windows?).and_return(true)
       file_uri = PuppetLanguageServer::UriHelper.build_file_uri(subject.store_root_path) + '/plans/test.pp'
-      expect(subject.module_plan_file?(file_uri)).to be(true)
+      expect(subject.plan_file?(file_uri)).to be(true)
       file_uri = PuppetLanguageServer::UriHelper.build_file_uri(subject.store_root_path.upcase) + '/plans/test.pp'
-      expect(subject.module_plan_file?(file_uri)).to be(true)
+      expect(subject.plan_file?(file_uri)).to be(true)
     end
 
     it 'should detect plan files as case sensitive not on Windows' do
       allow(subject).to receive(:windows?).and_return(false)
       file_uri = PuppetLanguageServer::UriHelper.build_file_uri(subject.store_root_path) + '/plans/test.pp'
-      expect(subject.module_plan_file?(file_uri)).to be(true)
+      expect(subject.plan_file?(file_uri)).to be(true)
       file_uri = PuppetLanguageServer::UriHelper.build_file_uri(subject.store_root_path).upcase + '/plans/test.pp'
-      expect(subject.module_plan_file?(file_uri.upcase)).to be(false)
+      expect(subject.plan_file?(file_uri.upcase)).to be(false)
     end
   end
 

--- a/spec/languageserver/unit/puppet-languageserver/document_store_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/document_store_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+describe 'PuppetLanguageServer::DocumentStore' do
+  let(:subject) { PuppetLanguageServer::DocumentStore }
+
+  describe '#module_plan_file?' do
+    before(:each) do
+      # Assume we are not in any module or control repo. Just a bare file
+      allow(subject).to receive(:store_has_module_metadata?).and_return(false)
+      allow(subject).to receive(:store_has_environmentconf?).and_return(false)
+    end
+
+    plan_files = [
+      'project/Boltdir/site-modules/project/plans/manifests/init.pp',
+      'plans/test.pp',
+      'plans/a/b/c/something.pp',
+      'project/Boltdir/site-modules/project/plans/foo/bar/wizz/diagnose.pp',
+      'something/plans/foo/bar/wizz/diagnose.pp'
+    ]
+
+    not_plan_files = [
+      'project/Boltdir/site-modules/project/manifests/plans/init.pp',
+      'something/plan__s/test.pp',
+      'plantest.pp',
+      'project/Boltdir/site-modules/project/manifests/init.pp'
+    ]
+
+    prefixes = ['/', 'C:/']
+
+    context 'for files which are plans' do
+      plan_files.each do |testcase|
+        prefixes.each do |prefix|
+          it "should detect '#{prefix}#{testcase}' as a plan file" do
+            file_uri = PuppetLanguageServer::UriHelper.build_file_uri(prefix + testcase)
+            expect(subject.module_plan_file?(file_uri)).to be(true)
+          end
+        end
+      end
+
+      it 'should detect plan files in a case insensitive way when on Windows' do
+        allow(subject).to receive(:windows?).and_return(true)
+        file_uri = plan_files[0]
+        expect(subject.module_plan_file?(file_uri)).to be(true)
+        expect(subject.module_plan_file?(file_uri.upcase)).to be(true)
+      end
+
+      it 'should detect plan files in a case sensitive way when not on Windows' do
+        allow(subject).to receive(:windows?).and_return(false)
+        file_uri = plan_files[0]
+        expect(subject.module_plan_file?(file_uri)).to be(true)
+        expect(subject.module_plan_file?(file_uri.upcase)).to be(false)
+      end
+    end
+
+    context 'for files which are not plans' do
+      not_plan_files.each do |testcase|
+        prefixes.each do |prefix|
+          it "should not detect '#{prefix}#{testcase}' as a plan file" do
+            file_uri = PuppetLanguageServer::UriHelper.build_file_uri(prefix + testcase)
+            expect(subject.module_plan_file?(file_uri)).to be(false)
+          end
+        end
+      end
+
+      it 'should detect plan files in a case insensitive way when on Windows' do
+        allow(subject).to receive(:windows?).and_return(true)
+        file_uri = not_plan_files[0]
+        expect(subject.module_plan_file?(file_uri)).to be(false)
+        expect(subject.module_plan_file?(file_uri.upcase)).to be(false)
+      end
+
+      it 'should detect plan files in a case sensitive way when not on Windows' do
+        allow(subject).to receive(:windows?).and_return(false)
+        file_uri = not_plan_files[0]
+        expect(subject.module_plan_file?(file_uri)).to be(false)
+        expect(subject.module_plan_file?(file_uri.upcase)).to be(false)
+      end
+    end
+  end
+end

--- a/spec/languageserver/unit/puppet-languageserver/document_store_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/document_store_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'PuppetLanguageServer::DocumentStore' do
   let(:subject) { PuppetLanguageServer::DocumentStore }
 
-  describe '#module_plan_file?' do
+  describe '#plan_file?' do
     before(:each) do
       # Assume we are not in any module or control repo. Just a bare file
       allow(subject).to receive(:store_has_module_metadata?).and_return(false)
@@ -32,7 +32,7 @@ describe 'PuppetLanguageServer::DocumentStore' do
         prefixes.each do |prefix|
           it "should detect '#{prefix}#{testcase}' as a plan file" do
             file_uri = PuppetLanguageServer::UriHelper.build_file_uri(prefix + testcase)
-            expect(subject.module_plan_file?(file_uri)).to be(true)
+            expect(subject.plan_file?(file_uri)).to be(true)
           end
         end
       end
@@ -40,15 +40,15 @@ describe 'PuppetLanguageServer::DocumentStore' do
       it 'should detect plan files in a case insensitive way when on Windows' do
         allow(subject).to receive(:windows?).and_return(true)
         file_uri = plan_files[0]
-        expect(subject.module_plan_file?(file_uri)).to be(true)
-        expect(subject.module_plan_file?(file_uri.upcase)).to be(true)
+        expect(subject.plan_file?(file_uri)).to be(true)
+        expect(subject.plan_file?(file_uri.upcase)).to be(true)
       end
 
       it 'should detect plan files in a case sensitive way when not on Windows' do
         allow(subject).to receive(:windows?).and_return(false)
         file_uri = plan_files[0]
-        expect(subject.module_plan_file?(file_uri)).to be(true)
-        expect(subject.module_plan_file?(file_uri.upcase)).to be(false)
+        expect(subject.plan_file?(file_uri)).to be(true)
+        expect(subject.plan_file?(file_uri.upcase)).to be(false)
       end
     end
 
@@ -57,7 +57,7 @@ describe 'PuppetLanguageServer::DocumentStore' do
         prefixes.each do |prefix|
           it "should not detect '#{prefix}#{testcase}' as a plan file" do
             file_uri = PuppetLanguageServer::UriHelper.build_file_uri(prefix + testcase)
-            expect(subject.module_plan_file?(file_uri)).to be(false)
+            expect(subject.plan_file?(file_uri)).to be(false)
           end
         end
       end
@@ -65,15 +65,15 @@ describe 'PuppetLanguageServer::DocumentStore' do
       it 'should detect plan files in a case insensitive way when on Windows' do
         allow(subject).to receive(:windows?).and_return(true)
         file_uri = not_plan_files[0]
-        expect(subject.module_plan_file?(file_uri)).to be(false)
-        expect(subject.module_plan_file?(file_uri.upcase)).to be(false)
+        expect(subject.plan_file?(file_uri)).to be(false)
+        expect(subject.plan_file?(file_uri.upcase)).to be(false)
       end
 
       it 'should detect plan files in a case sensitive way when not on Windows' do
         allow(subject).to receive(:windows?).and_return(false)
         file_uri = not_plan_files[0]
-        expect(subject.module_plan_file?(file_uri)).to be(false)
-        expect(subject.module_plan_file?(file_uri.upcase)).to be(false)
+        expect(subject.plan_file?(file_uri)).to be(false)
+        expect(subject.plan_file?(file_uri.upcase)).to be(false)
       end
     end
   end

--- a/spec/languageserver/unit/puppet-languageserver/message_router_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/message_router_spec.rb
@@ -522,7 +522,7 @@ describe 'message_router' do
 
         it 'should set tasks_mode option if the file is Puppet plan file' do
           expect(PuppetLanguageServer::Manifest::CompletionProvider).to receive(:complete).with(Object,line_num,char_num,{:tasks_mode=>true}).and_return('something')
-          allow(PuppetLanguageServer::DocumentStore).to receive(:module_plan_file?).and_return true
+          allow(PuppetLanguageServer::DocumentStore).to receive(:plan_file?).and_return true
 
           subject.receive_request(request)
         end
@@ -623,7 +623,7 @@ describe 'message_router' do
 
         it 'should set tasks_mode option if the file is Puppet plan file' do
           expect(PuppetLanguageServer::Manifest::HoverProvider).to receive(:resolve).with(Object,line_num,char_num,{:tasks_mode=>true}).and_return('something')
-          allow(PuppetLanguageServer::DocumentStore).to receive(:module_plan_file?).and_return true
+          allow(PuppetLanguageServer::DocumentStore).to receive(:plan_file?).and_return true
 
           subject.receive_request(request)
         end
@@ -692,7 +692,7 @@ describe 'message_router' do
         it 'should set tasks_mode option if the file is Puppet plan file' do
           expect(PuppetLanguageServer::Manifest::DefinitionProvider).to receive(:find_definition)
             .with(Object,line_num,char_num,{:tasks_mode=>true}).and_return('something')
-          allow(PuppetLanguageServer::DocumentStore).to receive(:module_plan_file?).and_return true
+          allow(PuppetLanguageServer::DocumentStore).to receive(:plan_file?).and_return true
 
           subject.receive_request(request)
         end
@@ -755,7 +755,7 @@ describe 'message_router' do
         it 'should set tasks_mode option if the file is Puppet plan file' do
           expect(PuppetLanguageServer::Manifest::DocumentSymbolProvider).to receive(:extract_document_symbols)
             .with(Object,{:tasks_mode=>true}).and_return('something')
-          allow(PuppetLanguageServer::DocumentStore).to receive(:module_plan_file?).and_return true
+          allow(PuppetLanguageServer::DocumentStore).to receive(:plan_file?).and_return true
 
           subject.receive_request(request)
         end


### PR DESCRIPTION
Fixes #127 
Fixes #128
Fixes #131

Previously Puppet Plan files had to exist within a Module however with the
Boltdir being introduced this is no longer true.  This commit updates the
detection to remove the module metadata.json requirement and use the pathname
instead.

Previously the plan detection method was called module_plan_file? however as the
module part is no longer required, the name is now plan_file?.
