### PR TITLE
(maint) Pin YARD to 0.9.19

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,9 @@ group :development do
   # The puppet-strings gem is not available in the Puppet Agent, but is in the PDK. We add it to the
   # Gemfile here for testing and development.
   gem "puppet-strings", "~> 2.0", :require => false
+  # Due to PDOC-283 we need to pin YARD at 0.9.19 until that issue is resolved and
+  # released in a new version of puppet-strings
+  gem "yard", "< 0.9.19", :require => false
 
   case RUBY_PLATFORM
   when /darwin/


### PR DESCRIPTION
Due to PDOC-283 [1] YARD needs to be pinned below 0.9.20 to pass our
integration tests. As this is only affecting a feature behind a flag, there is
no need to add a workaround.  Once puppet-strings is updated and released this
pin can be removed.

[1]https://tickets.puppetlabs.com/browse/PDOC-283
