### PR TITLE
(GH-147) Gracefully fail on LoadError when compiling manifests

### DIFF
--- a/lib/puppet-languageserver-sidecar/puppet_parser_helper.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_parser_helper.rb
@@ -21,6 +21,8 @@ module PuppetLanguageServerSidecar
         end
       rescue StandardError => e
         result.set_error("Error while parsing the file. #{e}")
+      rescue LoadError => e
+        result.set_error("Load error while parsing the file. #{e}")
       end
 
       result


### PR DESCRIPTION
Fixes #147 

Note - Technically this doesn't fix the error, but at least Editor Services will not crashing or throw bad data.  The fact a gem is missing from the ruby environment is outside the control of Editor Services.

Previously the sidecar would error completely when a LoadError was encountered.
This could be caused by gem Facter trying to load libraries which are not
present.  StandardError does not trap these.  This commit also traps the
LoadError and allows the sidecar to return a properly formatted response to
Editor Services intead of dumping error text to STDERR.
