### PR TITLE
(GH-106) Update puppet-lint to 2.3.6

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -49,7 +49,7 @@ task :gem_revendor do
     {
       :directory => 'puppet-lint',
       :github_repo => 'https://github.com/rodjek/puppet-lint.git',
-      :github_ref => '2.3.5',
+      :github_ref => '2.3.6',
     },
     {
       :directory => 'hiera-eyaml',

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -11,6 +11,6 @@ Note - To improve the packaging size, test files etc. were stripped from the Gem
 Gem List
 --------
 
-* puppet-lint (https://github.com/rodjek/puppet-lint.git ref 2.3.5)
+* puppet-lint (https://github.com/rodjek/puppet-lint.git ref 2.3.6)
 * hiera-eyaml (https://github.com/voxpupuli/hiera-eyaml ref v2.1.0)
 

--- a/vendor/puppet-lint/CHANGELOG.md
+++ b/vendor/puppet-lint/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Change Log
 
+## [2.3.6](https://github.com/rodjek/puppet-lint/tree/2.3.6) (2018-07-09)
+[Full Changelog](https://github.com/rodjek/puppet-lint/compare/2.3.5...2.3.6)
+
+**Fixed bugs:**
+
+- --fix does not work with require arrows in certain situations [\#799](https://github.com/rodjek/puppet-lint/issues/799)
+- Error with --fix when no whitespace before hashrocket in resource attribute list [\#798](https://github.com/rodjek/puppet-lint/issues/798)
+- puppet-lint --fix strips comments when fixing arrow\_on\_right\_operand\_line [\#792](https://github.com/rodjek/puppet-lint/issues/792)
+- Crash report, reason unclear [\#781](https://github.com/rodjek/puppet-lint/issues/781)
+- crash in fix mode with multiple trailing arrows [\#776](https://github.com/rodjek/puppet-lint/issues/776)
+- Error negative argument if opening brace on the same line and following element longer [\#771](https://github.com/rodjek/puppet-lint/issues/771)
+- ArgumentError: negative argument [\#723](https://github.com/rodjek/puppet-lint/issues/723)
+
+**Merged pull requests:**
+
+- \(\#771\) Handle arrow alignment when arrow column \< opening brace column... [\#819](https://github.com/rodjek/puppet-lint/pull/819) ([rodjek](https://github.com/rodjek))
+- Less aggressive fix method for arrow\_on\_right\_operand\_line [\#817](https://github.com/rodjek/puppet-lint/pull/817) ([rodjek](https://github.com/rodjek))
+- Check if token still exists before fixing trailing\_whitespace [\#816](https://github.com/rodjek/puppet-lint/pull/816) ([rodjek](https://github.com/rodjek))
+- Run all the checks before fixing problems [\#815](https://github.com/rodjek/puppet-lint/pull/815) ([rodjek](https://github.com/rodjek))
+
 ## [2.3.5](https://github.com/rodjek/puppet-lint/tree/2.3.5) (2018-03-27)
 [Full Changelog](https://github.com/rodjek/puppet-lint/compare/2.3.4...2.3.5)
 

--- a/vendor/puppet-lint/appveyor.yml
+++ b/vendor/puppet-lint/appveyor.yml
@@ -14,6 +14,10 @@ environment:
     - RUBY_VERSION: 23-x64
     - RUBY_VERSION: 24-x64
 
+matrix:
+  allow_failures:
+    - RUBY_VERSION: 193
+
 install:
   - SET PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
   - SET LOG_SPEC_ORDER=true

--- a/vendor/puppet-lint/lib/puppet-lint/checks.rb
+++ b/vendor/puppet-lint/lib/puppet-lint/checks.rb
@@ -54,11 +54,15 @@ class PuppetLint::Checks
   def run(fileinfo, data)
     load_data(fileinfo, data)
 
+    checks_run = []
     enabled_checks.each do |check|
       klass = PuppetLint.configuration.check_object[check].new
       # FIXME: shadowing #problems
       problems = klass.run
+      checks_run << [klass, problems]
+    end
 
+    checks_run.each do |klass, problems|
       if PuppetLint.configuration.fix
         @problems.concat(klass.fix_problems)
       else

--- a/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/arrow_on_right_operand_line.rb
+++ b/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/arrow_on_right_operand_line.rb
@@ -9,7 +9,7 @@ PuppetLint.new_check(:arrow_on_right_operand_line) do
 
       notify(
         :warning,
-        :message =>  'arrow should be on the right operand\'s line',
+        :message => "arrow should be on the right operand's line",
         :line    => token.line,
         :column  => token.column,
         :token   => token
@@ -18,27 +18,22 @@ PuppetLint.new_check(:arrow_on_right_operand_line) do
   end
 
   def fix(problem)
-    token = problem[:token]
+    return if problem[:token].nil?
 
-    prev_code_token = token.prev_code_token
-    next_code_token = token.next_code_token
-    indent_token = prev_code_token.prev_token_of(:INDENT)
+    arrow_token = problem[:token]
+    left_operand_token = arrow_token.prev_code_token
+    right_operand_token = arrow_token.next_code_token
 
-    # Delete all tokens between the two code tokens the anchor is between
-    temp_token = prev_code_token
-    while (temp_token = temp_token.next_token) && (temp_token != next_code_token)
-      remove_token(temp_token) unless temp_token == token
-    end
+    # Move arrow token to just before the right operand
+    remove_token(arrow_token)
+    right_operand_index = tokens.index(right_operand_token)
+    add_token(right_operand_index, arrow_token)
+    whitespace_token = PuppetLint::Lexer::Token.new(:WHITESPACE, ' ', right_operand_token.line, 3)
+    add_token(right_operand_index + 1, whitespace_token)
 
-    # Insert a newline and an indent before the arrow
-    index = tokens.index(token)
-    newline_token = PuppetLint::Lexer::Token.new(:NEWLINE, "\n", token.line, 0)
-    add_token(index, newline_token)
-    add_token(index + 1, indent_token) if indent_token
-
-    # Insert a space between the arrow and the following code token
-    index = tokens.index(token)
-    whitespace_token = PuppetLint::Lexer::Token.new(:WHITESPACE, ' ', token.line, 3)
-    add_token(index + 1, whitespace_token)
+    # Remove trailing whitespace after left operand (if it exists)
+    return unless left_operand_token.next_token.type == :WHITESPACE
+    trailing_whitespace_token = left_operand_token.next_token
+    remove_token(trailing_whitespace_token) if [:NEWLINE, :WHITESPACE].include?(trailing_whitespace_token.next_token.type)
   end
 end

--- a/vendor/puppet-lint/lib/puppet-lint/plugins/check_whitespace/trailing_whitespace.rb
+++ b/vendor/puppet-lint/lib/puppet-lint/plugins/check_whitespace/trailing_whitespace.rb
@@ -20,6 +20,8 @@ PuppetLint.new_check(:trailing_whitespace) do
   end
 
   def fix(problem)
+    return if problem[:token].nil?
+
     prev_token = problem[:token].prev_token
     next_token = problem[:token].next_token
     prev_token.next_token = next_token

--- a/vendor/puppet-lint/lib/puppet-lint/version.rb
+++ b/vendor/puppet-lint/lib/puppet-lint/version.rb
@@ -1,3 +1,3 @@
 class PuppetLint
-  VERSION = '2.3.5'.freeze
+  VERSION = '2.3.6'.freeze
 end


### PR DESCRIPTION
Fixed #106

This commit updates the vendored puppet-lint gem to 2.3.6.