### PR TITLE
(GH-55) Refactor Test Debug Client and add test for Next

### DIFF
--- a/spec/debugserver/fixtures/environments/testfixtures/manifests/kitchen_sink.pp
+++ b/spec/debugserver/fixtures/environments/testfixtures/manifests/kitchen_sink.pp
@@ -19,6 +19,10 @@ class nestedclass {
   }
 }
 
+class ignoreclass {
+  notify {'ignoreclass': }
+}
+
 # Class: democlass
 #
 class democlass {
@@ -27,6 +31,8 @@ class democlass {
   include nestedclass
 
   $after_var = 'after'
+
+  include ignoreclass
 
   notify {'demo_notify': }
 }

--- a/spec/debugserver/integration/puppet-debugserver/end_to_end_spec.rb
+++ b/spec/debugserver/integration/puppet-debugserver/end_to_end_spec.rb
@@ -21,6 +21,7 @@ describe 'End to End Testing' do
 
     # Now connect to the Debug Server
     @client = DebugClient.new(@debug_host, @debug_port)
+    @client.debug = !ENV['SPEC_DEBUG'].nil?
   }
 
   after(:each) {
@@ -39,15 +40,15 @@ describe 'End to End Testing' do
     it 'should process the manifest and exit with 0' do
       skip("Puppet 6 is not supported") if Gem::Version.new(Puppet.version) >= Gem::Version.new('6.0.0')
       # initialize_request
-      @client.send_data(initialize_request(@client.next_seq_id))
+      @client.send_data(@client.initialize_request(@client.next_seq_id))
       expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
 
       # launch_request
-      @client.send_data(launch_request(@client.next_seq_id, manifest_file, noop, args))
+      @client.send_data(@client.launch_request(@client.next_seq_id, manifest_file, noop, args))
       expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
 
       # configuration_done_request
-      @client.send_data(configuration_done_request(@client.next_seq_id))
+      @client.send_data(@client.configuration_done_request(@client.next_seq_id))
       expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
 
       # Wait for the puppet run to complete
@@ -68,15 +69,15 @@ describe 'End to End Testing' do
     it 'should process the manifest and exit with 1' do
       skip("Puppet 6 is not supported") if Gem::Version.new(Puppet.version) >= Gem::Version.new('6.0.0')
       # initialize_request
-      @client.send_data(initialize_request(@client.next_seq_id))
+      @client.send_data(@client.initialize_request(@client.next_seq_id))
       expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
 
       # launch_request
-      @client.send_data(launch_request(@client.next_seq_id, manifest_file, noop, args))
+      @client.send_data(@client.launch_request(@client.next_seq_id, manifest_file, noop, args))
       expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
 
       # configuration_done_request
-      @client.send_data(configuration_done_request(@client.next_seq_id))
+      @client.send_data(@client.configuration_done_request(@client.next_seq_id))
       expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
 
       # Wait for the exception to raise
@@ -88,7 +89,7 @@ describe 'End to End Testing' do
 
       # Ensure it was raised on Line 3
       # Get the stack trace list
-      @client.send_data(stacktrace_request(@client.next_seq_id, thread_id))
+      @client.send_data(@client.stacktrace_request(@client.next_seq_id, thread_id))
       expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
       result = @client.data_from_request_seq_id(@client.current_seq_id)
       # As we're only in the root, only two frames should be available.  The error and where it was called from
@@ -98,7 +99,7 @@ describe 'End to End Testing' do
       expect(result['body']['stackFrames'][1]).to include('line' => 3)
 
       # continue_request
-      @client.send_data(continue_request(@client.next_seq_id, thread_id))
+      @client.send_data(@client.continue_request(@client.next_seq_id, thread_id))
       expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
 
       # Wait for the puppet run to complete
@@ -143,11 +144,11 @@ describe 'End to End Testing' do
     it 'should process the manifest and exit with 0' do
       skip("Puppet 6 is not supported") if Gem::Version.new(Puppet.version) >= Gem::Version.new('6.0.0')
       # initialize_request
-      @client.send_data(initialize_request(@client.next_seq_id))
+      @client.send_data(@client.initialize_request(@client.next_seq_id))
       expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
 
       # set_breakpoints_request
-      @client.send_data(set_breakpoints_request(@client.next_seq_id,
+      @client.send_data(@client.set_breakpoints_request(@client.next_seq_id,
         {
           'source'      => {
             'name' => 'kitchen_sink.pp',
@@ -170,7 +171,7 @@ describe 'End to End Testing' do
       expect(result['body']['breakpoints'][1]['verified']).to be true
 
       # set_function_breakpoints_request
-      @client.send_data(set_function_breakpoints_request(@client.next_seq_id,
+      @client.send_data(@client.set_function_breakpoints_request(@client.next_seq_id,
         {
           'breakpoints' => [
             { 'name' => 'alert' }
@@ -183,11 +184,11 @@ describe 'End to End Testing' do
       expect(result['body']['breakpoints'][0]['verified']).to be true
 
       # launch_request
-      @client.send_data(launch_request(@client.next_seq_id, manifest_file, noop, args))
+      @client.send_data(@client.launch_request(@client.next_seq_id, manifest_file, noop, args))
       expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
 
       # configuration_done_request
-      @client.send_data(configuration_done_request(@client.next_seq_id))
+      @client.send_data(@client.configuration_done_request(@client.next_seq_id))
       expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
 
       # -----
@@ -203,7 +204,7 @@ describe 'End to End Testing' do
       thread_id = result['body']['threadId']
 
       # Get the stack trace list
-      @client.send_data(stacktrace_request(@client.next_seq_id, thread_id))
+      @client.send_data(@client.stacktrace_request(@client.next_seq_id, thread_id))
       expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
       result = @client.data_from_request_seq_id(@client.current_seq_id)
       # As we're only in the root, only one frame should be available
@@ -212,7 +213,7 @@ describe 'End to End Testing' do
       expect(result['body']['stackFrames'][0]).to include('line' => 45)
 
       # Get the available scopes list
-      @client.send_data(scopes_request(@client.next_seq_id))
+      @client.send_data(@client.scopes_request(@client.next_seq_id))
       expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
       result = @client.data_from_request_seq_id(@client.current_seq_id)
       expect(result['success']).to be true
@@ -221,7 +222,7 @@ describe 'End to End Testing' do
       variables_reference = result['body']['scopes'][0]['variablesReference']
 
       # Get the variables list
-      @client.send_data(variables_request(@client.next_seq_id, variables_reference))
+      @client.send_data(@client.variables_request(@client.next_seq_id, variables_reference))
       expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
       result = @client.data_from_request_seq_id(@client.current_seq_id)
 
@@ -233,7 +234,7 @@ describe 'End to End Testing' do
       obj = result['body']['variables'].find { |item| item['name'] == 'a_test_array'}
       expect(obj).to_not be nil
       # Get more details about the $a_test_array variable
-      @client.send_data(variables_request(@client.next_seq_id, obj['variablesReference']))
+      @client.send_data(@client.variables_request(@client.next_seq_id, obj['variablesReference']))
       expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
       result = @client.data_from_request_seq_id(@client.current_seq_id)
       # Ensure the $a_test_array variable contents is correct
@@ -245,15 +246,15 @@ describe 'End to End Testing' do
       # Now to Step In twice and we should be inside the class called democlass
       # -----
       @client.clear_messages!
-      @client.send_data(stepin_request(@client.next_seq_id, thread_id))
+      @client.send_data(@client.stepin_request(@client.next_seq_id, thread_id))
       expect(@client).to receive_event_within_timeout(['stopped', 60])
 
       @client.clear_messages!
-      @client.send_data(stepin_request(@client.next_seq_id, thread_id))
+      @client.send_data(@client.stepin_request(@client.next_seq_id, thread_id))
       expect(@client).to receive_event_within_timeout(['stopped', 60])
 
       # Get the stack trace list
-      @client.send_data(stacktrace_request(@client.next_seq_id, thread_id))
+      @client.send_data(@client.stacktrace_request(@client.next_seq_id, thread_id))
       expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
       result = @client.data_from_request_seq_id(@client.current_seq_id)
       # The stack should be two levels deep (root -> democlass)
@@ -269,7 +270,7 @@ describe 'End to End Testing' do
 
       # Wait for the breakpoint to be hit
       @client.clear_messages!
-      @client.send_data(continue_request(@client.next_seq_id, thread_id))
+      @client.send_data(@client.continue_request(@client.next_seq_id, thread_id))
       expect(@client).to receive_event_within_timeout(['stopped', 60])
       result = @client.data_from_event_name('stopped')
       expect(result['body']['reason']).to eq('function breakpoint')
@@ -277,7 +278,7 @@ describe 'End to End Testing' do
       thread_id = result['body']['threadId']
 
       # Get the stack trace list
-      @client.send_data(stacktrace_request(@client.next_seq_id, thread_id))
+      @client.send_data(@client.stacktrace_request(@client.next_seq_id, thread_id))
       expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
       result = @client.data_from_request_seq_id(@client.current_seq_id)
       # The stack should be three levels deep (root -> democlass -> nestedclass)
@@ -289,17 +290,17 @@ describe 'End to End Testing' do
 
       # Evaluate that $before_var exists but $after_var does not.  Also add $mid_var to check later
       # - Check $democlass::before_var
-      @client.send_data(evaluate_request(@client.next_seq_id, '$democlass::before_var', 0))
+      @client.send_data(@client.evaluate_request(@client.next_seq_id, '$democlass::before_var', 0))
       expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
       result = @client.data_from_request_seq_id(@client.current_seq_id)
       expect(result['body']['result']).to eq('before')
       # - Check $democlass::after_var
-      @client.send_data(evaluate_request(@client.next_seq_id, '$democlass::after_var', 0))
+      @client.send_data(@client.evaluate_request(@client.next_seq_id, '$democlass::after_var', 0))
       expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
       result = @client.data_from_request_seq_id(@client.current_seq_id)
       expect(result['body']['result']).to eq('')
       # - Create $mid_var
-      @client.send_data(evaluate_request(@client.next_seq_id, '$mid_var = \'middle\'', 0))
+      @client.send_data(@client.evaluate_request(@client.next_seq_id, '$mid_var = \'middle\'', 0))
       expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
       result = @client.data_from_request_seq_id(@client.current_seq_id)
       expect(result['body']['result']).to eq('middle')
@@ -308,7 +309,7 @@ describe 'End to End Testing' do
       # Change the function break points from alert to notice, mid-debug which should be line 49
       #
       # set_function_breakpoints_request
-      @client.send_data(set_function_breakpoints_request(@client.next_seq_id,
+      @client.send_data(@client.set_function_breakpoints_request(@client.next_seq_id,
         {
           'breakpoints' => [
             { 'name' => 'notice' }
@@ -325,12 +326,12 @@ describe 'End to End Testing' do
       # Line 35
       #
       @client.clear_messages!
-      @client.send_data(stepout_request(@client.next_seq_id, thread_id))
+      @client.send_data(@client.stepout_request(@client.next_seq_id, thread_id))
       expect(@client).to receive_event_within_timeout(['stopped', 10])
       result = @client.data_from_event_name('stopped')
 
       # Get the stack trace list
-      @client.send_data(stacktrace_request(@client.next_seq_id, thread_id))
+      @client.send_data(@client.stacktrace_request(@client.next_seq_id, thread_id))
       expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
       result = @client.data_from_request_seq_id(@client.current_seq_id)
       # The stack should be two levels deep (root -> democlass)
@@ -345,15 +346,15 @@ describe 'End to End Testing' do
       # Line 37
       # -----
       @client.clear_messages!
-      @client.send_data(next_request(@client.next_seq_id, thread_id))
+      @client.send_data(@client.next_request(@client.next_seq_id, thread_id))
       expect(@client).to receive_event_within_timeout(['stopped', 60])
 
       @client.clear_messages!
-      @client.send_data(next_request(@client.next_seq_id, thread_id))
+      @client.send_data(@client.next_request(@client.next_seq_id, thread_id))
       expect(@client).to receive_event_within_timeout(['stopped', 60])
 
       # Get the stack trace list
-      @client.send_data(stacktrace_request(@client.next_seq_id, thread_id))
+      @client.send_data(@client.stacktrace_request(@client.next_seq_id, thread_id))
       expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
       result = @client.data_from_request_seq_id(@client.current_seq_id)
       result['body']['stackFrames'].each { |item| puts item['line'] }
@@ -368,7 +369,7 @@ describe 'End to End Testing' do
       # Dymically change the breakpoint list
       #
       # set_breakpoints_request
-      @client.send_data(set_breakpoints_request(@client.next_seq_id,
+      @client.send_data(@client.set_breakpoints_request(@client.next_seq_id,
         {
           'source'      => {
             'name' => 'kitchen_sink.pp',
@@ -392,14 +393,14 @@ describe 'End to End Testing' do
 
       # Wait for the breakpoint to be hit
       @client.clear_messages!
-      @client.send_data(continue_request(@client.next_seq_id, thread_id))
+      @client.send_data(@client.continue_request(@client.next_seq_id, thread_id))
       expect(@client).to receive_event_within_timeout(['stopped', 60])
       result = @client.data_from_event_name('stopped')
       expect(result['body']['reason']).to eq('breakpoint')
       thread_id = result['body']['threadId']
 
       # Get the stack trace list
-      @client.send_data(stacktrace_request(@client.next_seq_id, thread_id))
+      @client.send_data(@client.stacktrace_request(@client.next_seq_id, thread_id))
       expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
       result = @client.data_from_request_seq_id(@client.current_seq_id)
       # As we're only in the root, only one frame should be available
@@ -411,7 +412,7 @@ describe 'End to End Testing' do
       # Clear all breakpoints
       #
       # set_breakpoints_request
-      @client.send_data(set_breakpoints_request(@client.next_seq_id,
+      @client.send_data(@client.set_breakpoints_request(@client.next_seq_id,
         {
           'source'      => {
             'name' => 'kitchen_sink.pp',
@@ -432,7 +433,7 @@ describe 'End to End Testing' do
 
       # Wait for the breakpoint to be hit
       @client.clear_messages!
-      @client.send_data(continue_request(@client.next_seq_id, thread_id))
+      @client.send_data(@client.continue_request(@client.next_seq_id, thread_id))
       expect(@client).to receive_event_within_timeout(['stopped', 60])
       result = @client.data_from_event_name('stopped')
       expect(result['body']['reason']).to eq('function breakpoint')
@@ -440,7 +441,7 @@ describe 'End to End Testing' do
       thread_id = result['body']['threadId']
 
       # Get the stack trace list
-      @client.send_data(stacktrace_request(@client.next_seq_id, thread_id))
+      @client.send_data(@client.stacktrace_request(@client.next_seq_id, thread_id))
       expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
       result = @client.data_from_request_seq_id(@client.current_seq_id)
       # As we're only in the root, only one frame should be available
@@ -449,12 +450,12 @@ describe 'End to End Testing' do
       expect(result['body']['stackFrames'][0]).to include('line' => 49)
 
       # Evaluate that $mid_var still exists
-      @client.send_data(evaluate_request(@client.next_seq_id, '$mid_var', 0))
+      @client.send_data(@client.evaluate_request(@client.next_seq_id, '$mid_var', 0))
       expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
       result = @client.data_from_request_seq_id(@client.current_seq_id)
       expect(result['body']['result']).to eq('middle')
 
-      @client.send_data(continue_request(@client.next_seq_id, thread_id))
+      @client.send_data(@client.continue_request(@client.next_seq_id, thread_id))
 
       # Wait for the puppet run to complete
       expect(@client).to receive_event_within_timeout(['terminated', 60])

--- a/spec/debugserver/integration/puppet-debugserver/json_handler_spec.rb
+++ b/spec/debugserver/integration/puppet-debugserver/json_handler_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_debug_helper'
+require 'spec_debug_client'
 require 'json'
 
 class StubbedSimpleServerConnection < PuppetEditorServices::SimpleServerConnectionBase
@@ -35,6 +36,7 @@ describe 'PuppetDebugServer::JSONHandler' do
     connection: StubbedSimpleServerConnection.new
   }}
   let(:subject) { PuppetDebugServer::JSONHandler.new(subject_options) }
+  let(:client) { DebugClient.new }
 
   before(:each) {
     allow(subject).to receive(:close_connection_after_writing).and_return(true)
@@ -46,7 +48,7 @@ describe 'PuppetDebugServer::JSONHandler' do
 
   context 'During initial session setup' do
     it 'should respond with the correct capabilities' do
-      subject.parse_data(initialize_request)
+      subject.parse_data(client.initialize_request)
 
       response = data_from_request_seq_id(subject.client_connection, 1)
       expect(response['body']['supportsConfigurationDoneRequest']).to be true
@@ -59,22 +61,22 @@ describe 'PuppetDebugServer::JSONHandler' do
     end
 
     it 'should respond with an Initialized event' do
-      subject.parse_data(initialize_request)
+      subject.parse_data(client.initialize_request)
 
       response = data_from_event_name(subject.client_connection, 'initialized')
       expect(response).to_not be nil
     end
 
     it 'should respond with failures for debug session commands' do
-      subject.parse_data(initialize_request)
-      subject.parse_data(threads_request(2))
-      subject.parse_data(stacktrace_request(3))
-      subject.parse_data(scopes_request(4))
-      subject.parse_data(variables_request(5))
-      subject.parse_data(evaluate_request(6))
-      subject.parse_data(stepin_request(7))
-      subject.parse_data(stepout_request(8))
-      subject.parse_data(next_request(9))
+      subject.parse_data(client.initialize_request)
+      subject.parse_data(client.threads_request(2))
+      subject.parse_data(client.stacktrace_request(3))
+      subject.parse_data(client.scopes_request(4))
+      subject.parse_data(client.variables_request(5))
+      subject.parse_data(client.evaluate_request(6))
+      subject.parse_data(client.stepin_request(7))
+      subject.parse_data(client.stepout_request(8))
+      subject.parse_data(client.next_request(9))
 
       {
         2 => 'threads',
@@ -94,10 +96,10 @@ describe 'PuppetDebugServer::JSONHandler' do
     end
 
     it 'should increment the response sequence ID by one' do
-      subject.parse_data(initialize_request)
-      subject.parse_data(threads_request(10))
-      subject.parse_data(stacktrace_request(20))
-      subject.parse_data(scopes_request(30))
+      subject.parse_data(client.initialize_request)
+      subject.parse_data(client.threads_request(10))
+      subject.parse_data(client.stacktrace_request(20))
+      subject.parse_data(client.scopes_request(30))
 
       last_seq_id = nil
       [10, 20, 30].each do |req_seq_id|
@@ -115,8 +117,8 @@ describe 'PuppetDebugServer::JSONHandler' do
   context 'Receiving a disconnect request' do
     it 'should close the connection' do
       expect(subject).to receive(:close_connection)
-      subject.parse_data(initialize_request)
-      subject.parse_data(disconnect_request(2))
+      subject.parse_data(client.initialize_request)
+      subject.parse_data(client.disconnect_request(2))
     end
   end
 end


### PR DESCRIPTION
Previously the kitchen_sink tests did not actually include a test for the 'next'
command.  This commit updates the test manifest fixture with an additional class
which is 'next'-d over and adds the test for this scenario.

---

Previously the methods for impersonating a Debug Client were a cross multiple
files.  This commit consolidates the debug client helpers into a single class
and updates the tests to use this class.