### PR TITLE
Revert "(maint) Pin YARD to 0.9.19"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,9 +27,6 @@ group :development do
   # The puppet-strings gem is not available in the Puppet Agent, but is in the PDK. We add it to the
   # Gemfile here for testing and development.
   gem "puppet-strings", "~> 2.0", :require => false
-  # Due to PDOC-283 we need to pin YARD at 0.9.19 until that issue is resolved and
-  # released in a new version of puppet-strings
-  gem "yard", "< 0.9.19", :require => false
 
   case RUBY_PLATFORM
   when /darwin/


### PR DESCRIPTION
This reverts commit a0fcdc174e7a40365b236202b3d37f067ad81296.

Puppet Strings 2.3.0 now works with yard 0.9.20