### PR TITLE
(maint) Add tests for roundtripping hash serialisation

### DIFF
--- a/lib/puppet-languageserver/sidecar_protocol.rb
+++ b/lib/puppet-languageserver/sidecar_protocol.rb
@@ -111,6 +111,13 @@ module PuppetLanguageServer
           self.length         = value['length']
           self
         end
+
+        private
+
+        def value_from_hash(hash, key)
+          # The key could be a Symbol or String in the hash
+          hash[key].nil? ? hash[key.to_s] : hash[key]
+        end
       end
 
       class BasePuppetObjectList < Array
@@ -173,9 +180,10 @@ module PuppetLanguageServer
           self.parameters = {}
           unless value['parameters'].nil?
             value['parameters'].each do |attr_name, obj_attr|
+              # TODO: This should be a class, not a hash
               parameters[attr_name] = {
-                :type => obj_attr['type'],
-                :doc  => obj_attr['doc']
+                :type => value_from_hash(obj_attr, :type),
+                :doc  => value_from_hash(obj_attr, :doc)
               }
             end
           end
@@ -204,7 +212,7 @@ module PuppetLanguageServer
           super.to_h.merge(
             'doc'              => doc,
             'function_version' => function_version,
-            'signatures'       => signatures
+            'signatures'       => signatures.map(&:to_h)
           )
         end
 
@@ -240,7 +248,7 @@ module PuppetLanguageServer
             'key'          => key,
             'doc'          => doc,
             'return_types' => return_types,
-            'parameters'   => parameters
+            'parameters'   => parameters.map(&:to_h)
           }
         end
 
@@ -311,10 +319,11 @@ module PuppetLanguageServer
           unless value['attributes'].nil?
             value['attributes'].each do |attr_name, obj_attr|
               attributes[attr_name.intern] = {
-                :type       => obj_attr['type'].intern,
-                :doc        => obj_attr['doc'],
-                :required?  => obj_attr['required?'],
-                :isnamevar? => obj_attr['isnamevar?']
+                # TODO: This should be a class, not a hash
+                :type       => value_from_hash(obj_attr, :type).intern,
+                :doc        => value_from_hash(obj_attr, :doc),
+                :required?  => value_from_hash(obj_attr, :required?),
+                :isnamevar? => value_from_hash(obj_attr, :isnamevar?)
               }
             end
           end

--- a/spec/languageserver/unit/puppet-languageserver/sidecar_protocol_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/sidecar_protocol_spec.rb
@@ -22,6 +22,12 @@ describe 'PuppetLanguageServer::Sidecar::Protocol' do
         expect(subject).to respond_to(testcase)
       end
     end
+
+    it 'should roundtrip to_h to from_h!' do
+      subject_as_hash = subject.to_h
+      copy = subject_klass.new.from_h!(subject_as_hash)
+      expect(subject_as_hash).to eq(copy.to_h)
+    end
   end
 
   shared_examples_for 'a base Sidecar Protocol Puppet object list' do


### PR DESCRIPTION
Previously the Sidecar Protocol had methods to convert to and from hash however
they were never tested to ensure that they could be "round-tripped", that is
converted to a hash and then back to a sidecar object with no loss of data. This
commit adds the test and corrects any behvaiour in the protocol implementation.
