### PR TITLE
(GH-163) Add aggregate metadata sidecar object and tasks

### DIFF
--- a/lib/puppet-languageserver-sidecar/puppet_strings_helper.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_strings_helper.rb
@@ -282,7 +282,7 @@ module PuppetLanguageServerSidecar
     attr_accessor :types
 
     def initialize(path = nil)
-      @path = path
+      @path      = path
       @classes   = PuppetLanguageServer::Sidecar::Protocol::PuppetClassList.new
       @functions = PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionList.new
       @types     = PuppetLanguageServer::Sidecar::Protocol::PuppetTypeList.new

--- a/lib/puppet_languageserver_sidecar.rb
+++ b/lib/puppet_languageserver_sidecar.rb
@@ -261,7 +261,7 @@ module PuppetLanguageServerSidecar
     when 'default_classes'
       cache = options[:disable_cache] ? PuppetLanguageServerSidecar::Cache::Null.new : PuppetLanguageServerSidecar::Cache::FileSystem.new
       if use_puppet_strings
-        PuppetLanguageServerSidecar::PuppetHelper.retrieve_via_puppet_strings(cache, :object_types => [:class])[:classes]
+        PuppetLanguageServerSidecar::PuppetHelper.retrieve_via_puppet_strings(cache, :object_types => [:class]).classes
       else
         PuppetLanguageServerSidecar::PuppetHelper.retrieve_classes(cache)
       end
@@ -269,7 +269,7 @@ module PuppetLanguageServerSidecar
     when 'default_functions'
       cache = options[:disable_cache] ? PuppetLanguageServerSidecar::Cache::Null.new : PuppetLanguageServerSidecar::Cache::FileSystem.new
       if use_puppet_strings
-        PuppetLanguageServerSidecar::PuppetHelper.retrieve_via_puppet_strings(cache, :object_types => [:function])[:functions]
+        PuppetLanguageServerSidecar::PuppetHelper.retrieve_via_puppet_strings(cache, :object_types => [:function]).functions
       else
         PuppetLanguageServerSidecar::PuppetHelper.retrieve_functions(cache)
       end
@@ -277,7 +277,7 @@ module PuppetLanguageServerSidecar
     when 'default_types'
       cache = options[:disable_cache] ? PuppetLanguageServerSidecar::Cache::Null.new : PuppetLanguageServerSidecar::Cache::FileSystem.new
       if use_puppet_strings
-        PuppetLanguageServerSidecar::PuppetHelper.retrieve_via_puppet_strings(cache, :object_types => [:type])[:types]
+        PuppetLanguageServerSidecar::PuppetHelper.retrieve_via_puppet_strings(cache, :object_types => [:type]).types
       else
         PuppetLanguageServerSidecar::PuppetHelper.retrieve_types(cache)
       end
@@ -314,7 +314,7 @@ module PuppetLanguageServerSidecar
         cache = options[:disable_cache] ? PuppetLanguageServerSidecar::Cache::Null.new : PuppetLanguageServerSidecar::Cache::FileSystem.new
         PuppetLanguageServerSidecar::PuppetHelper.retrieve_via_puppet_strings(cache,
                                                                               :object_types => [:class],
-                                                                              :root_path    => PuppetLanguageServerSidecar::Workspace.root_path)[:classes]
+                                                                              :root_path    => PuppetLanguageServerSidecar::Workspace.root_path).classes
       else
         PuppetLanguageServerSidecar::PuppetHelper.retrieve_classes(null_cache,
                                                                    :root_path => PuppetLanguageServerSidecar::Workspace.root_path)
@@ -328,7 +328,7 @@ module PuppetLanguageServerSidecar
         cache = options[:disable_cache] ? PuppetLanguageServerSidecar::Cache::Null.new : PuppetLanguageServerSidecar::Cache::FileSystem.new
         PuppetLanguageServerSidecar::PuppetHelper.retrieve_via_puppet_strings(cache,
                                                                               :object_types => [:function],
-                                                                              :root_path    => PuppetLanguageServerSidecar::Workspace.root_path)[:functions]
+                                                                              :root_path    => PuppetLanguageServerSidecar::Workspace.root_path).functions
       else
         PuppetLanguageServerSidecar::PuppetHelper.retrieve_functions(null_cache,
                                                                      :root_path => PuppetLanguageServerSidecar::Workspace.root_path)
@@ -341,7 +341,7 @@ module PuppetLanguageServerSidecar
         cache = options[:disable_cache] ? PuppetLanguageServerSidecar::Cache::Null.new : PuppetLanguageServerSidecar::Cache::FileSystem.new
         PuppetLanguageServerSidecar::PuppetHelper.retrieve_via_puppet_strings(cache,
                                                                               :object_types => [:type],
-                                                                              :root_path    => PuppetLanguageServerSidecar::Workspace.root_path)[:types]
+                                                                              :root_path    => PuppetLanguageServerSidecar::Workspace.root_path).types
       else
         PuppetLanguageServerSidecar::PuppetHelper.retrieve_types(null_cache)
       end

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_puppetstrings/featureflag_puppetstrings_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_puppetstrings/featureflag_puppetstrings_spec.rb
@@ -92,6 +92,37 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings', :if => G
     end
   end
 
+  describe 'when running default_aggregate action' do
+    let (:cmd_options) { ['--action', 'default_aggregate'] }
+
+    it 'should return a cachable deserializable aggregate object with all default metadata' do
+      expect_empty_cache
+
+      result = run_sidecar(cmd_options)
+      deserial = PuppetLanguageServer::Sidecar::Protocol::AggregateMetadata.new
+      expect { deserial.from_json!(result) }.to_not raise_error
+
+      # The contents of the result are tested later
+
+      # Now run using cached information
+      expect_populated_cache
+
+      result2 = run_sidecar(cmd_options)
+      deserial2 = PuppetLanguageServer::Sidecar::Protocol::AggregateMetadata.new()
+      expect { deserial2.from_json!(result2) }.to_not raise_error
+
+      deserial.class
+              .instance_methods(false)
+              .reject { |name| %i[to_json from_json! each_list append!].include?(name) }
+              .each do |method_name|
+        # There should be at least one item
+        expect(deserial.send(method_name).count).to be > 0
+        # Before and after should be the same
+        expect_same_array_content(deserial.send(method_name), deserial2.send(method_name))
+      end
+    end
+  end
+
   describe 'when running default_classes action' do
     let (:cmd_options) { ['--action', 'default_classes'] }
 
@@ -236,6 +267,37 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings', :if => G
       end
     end
 
+    describe 'when running workspace_aggregate action' do
+      let (:cmd_options) { ['--action', 'workspace_aggregate', '--local-workspace', workspace] }
+
+      it 'should return a cachable deserializable aggregate object with all default metadata' do
+        expect_empty_cache
+
+        result = run_sidecar(cmd_options)
+        deserial = PuppetLanguageServer::Sidecar::Protocol::AggregateMetadata.new
+        expect { deserial.from_json!(result) }.to_not raise_error
+
+        # The contents of the result are tested later
+
+        # Now run using cached information
+        expect_populated_cache
+
+        result2 = run_sidecar(cmd_options)
+        deserial2 = PuppetLanguageServer::Sidecar::Protocol::AggregateMetadata.new()
+        expect { deserial2.from_json!(result2) }.to_not raise_error
+
+        deserial.class
+                .instance_methods(false)
+                .reject { |name| %i[to_json from_json! each_list append!].include?(name) }
+                .each do |method_name|
+          # There should be at least one item
+          expect(deserial.send(method_name).count).to be > 0
+          # Before and after should be the same
+          expect_same_array_content(deserial.send(method_name), deserial2.send(method_name))
+        end
+      end
+    end
+
     describe 'when running workspace_classes action' do
       let (:cmd_options) { ['--action', 'workspace_classes', '--local-workspace', workspace] }
 
@@ -344,6 +406,37 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings', :if => G
 
           expect(deserial.dot_content).to match(/Envtype\[test\]/)
           expect(deserial.error_content.to_s).to eq('')
+        end
+      end
+    end
+
+    describe 'when running workspace_aggregate action' do
+      let (:cmd_options) { ['--action', 'workspace_aggregate', '--local-workspace', workspace] }
+
+      it 'should return a cachable deserializable aggregate object with all default metadata' do
+        expect_empty_cache
+
+        result = run_sidecar(cmd_options)
+        deserial = PuppetLanguageServer::Sidecar::Protocol::AggregateMetadata.new
+        expect { deserial.from_json!(result) }.to_not raise_error
+
+        # The contents of the result are tested later
+
+        # Now run using cached information
+        expect_populated_cache
+
+        result2 = run_sidecar(cmd_options)
+        deserial2 = PuppetLanguageServer::Sidecar::Protocol::AggregateMetadata.new()
+        expect { deserial2.from_json!(result2) }.to_not raise_error
+
+        deserial.class
+                .instance_methods(false)
+                .reject { |name| %i[to_json from_json! each_list append!].include?(name) }
+                .each do |method_name|
+          # There should be at least one item
+          expect(deserial.send(method_name).count).to be > 0
+          # Before and after should be the same
+          expect_same_array_content(deserial.send(method_name), deserial2.send(method_name))
         end
       end
     end

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/puppet-languageserver-sidecar_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/puppet-languageserver-sidecar_spec.rb
@@ -45,6 +45,16 @@ describe 'PuppetLanguageServerSidecar' do
     end
   end
 
+  describe 'when running default_aggregate action' do
+    let (:cmd_options) { ['--action', 'default_aggregate'] }
+
+    it 'should return an empty hash' do
+      result = run_sidecar(cmd_options)
+
+      expect(result).to eq('{}')
+    end
+  end
+
   describe 'when running default_classes action' do
     let (:cmd_options) { ['--action', 'default_classes'] }
 
@@ -123,6 +133,16 @@ describe 'PuppetLanguageServerSidecar' do
           expect(deserial.dot_content).to match(/Fixture\[test\]/)
           expect(deserial.error_content.to_s).to eq('')
         end
+      end
+    end
+
+    describe 'when running workspace_aggregate action' do
+      let (:cmd_options) { ['--action', 'workspace_aggregate', '--local-workspace', workspace] }
+
+      it 'should return an empty hash' do
+        result = run_sidecar(cmd_options)
+
+        expect(result).to eq('{}')
       end
     end
 
@@ -209,6 +229,16 @@ describe 'PuppetLanguageServerSidecar' do
           expect(deserial.dot_content).to match(/Envtype\[test\]/)
           expect(deserial.error_content.to_s).to eq('')
         end
+      end
+    end
+
+    describe 'when running workspace_aggregate action' do
+      let (:cmd_options) { ['--action', 'workspace_aggregate', '--local-workspace', workspace] }
+
+      it 'should return an empty hash' do
+        result = run_sidecar(cmd_options)
+
+        expect(result).to eq('{}')
       end
     end
 

--- a/spec/languageserver/unit/puppet-languageserver/sidecar_protocol_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/sidecar_protocol_spec.rb
@@ -14,6 +14,13 @@ describe 'PuppetLanguageServer::Sidecar::Protocol' do
 
       expect(serial).to be_a(String)
     end
+
+    it 'should roundtrip to_json to from_json!' do
+      subject_as_json = subject.to_json
+      copy = subject_klass.new.from_json!(subject_as_json)
+      expect(copy.to_json).to eq(subject_as_json)
+      expect(copy.hash).to eq(subject.hash)
+    end
   end
 
   shared_examples_for 'a base Sidecar Protocol Puppet object' do
@@ -435,5 +442,20 @@ describe 'PuppetLanguageServer::Sidecar::Protocol' do
     it "instance should have a childtype of Resource" do
       expect(subject.child_type).to eq(PuppetLanguageServer::Sidecar::Protocol::Resource)
     end
+  end
+
+  describe 'AggregateMetadata' do
+    let(:subject_klass) { PuppetLanguageServer::Sidecar::Protocol::AggregateMetadata }
+    let(:subject) {
+      value = subject_klass.new
+      (1..3).each do |_|
+        value.append!(random_sidecar_puppet_class)
+        value.append!(random_sidecar_puppet_function)
+        value.append!(random_sidecar_puppet_type)
+      end
+      value
+    }
+
+    it_should_behave_like 'a base Sidecar Protocol object'
   end
 end


### PR DESCRIPTION
Fixes #163 

Previously, to get all metadata information, the sidecar would need to be called
multiple times, however, with the puppetstrings featureflag, we can now evaluate
the metadata all at once.

---

This PR adds an AggregateMetadata object and two new tasks `default_aggregate` and `workspace_aggregate`