### PR TITLE
(GH-163) Use aggregate metadata actions for puppetstrings feature flag

### DIFF
--- a/lib/puppet-languageserver-sidecar/puppet_helper_puppetstrings.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_helper_puppetstrings.rb
@@ -83,7 +83,7 @@ module PuppetLanguageServerSidecar
       end
 
       # Remove Puppet3 functions which have a Puppet4 function already loaded
-      if object_types.include?(:function)
+      if object_types.include?(:function) && !result.functions.nil?
         pup4_functions = result.functions.select { |i| i.function_version == 4 }.map { |i| i.key }
         result.functions.reject! { |i| i.function_version == 3 && pup4_functions.include?(i.key) }
       end

--- a/lib/puppet-languageserver/puppet_helper.rb
+++ b/lib/puppet-languageserver/puppet_helper.rb
@@ -181,6 +181,11 @@ module PuppetLanguageServer
 
     # Workspace Loading
     def self.load_workspace_async
+      if PuppetLanguageServer.featureflag?('puppetstrings')
+        return true if PuppetLanguageServer::DocumentStore.store_root_path.nil?
+        sidecar_queue.enqueue('workspace_aggregate', ['--local-workspace', PuppetLanguageServer::DocumentStore.store_root_path])
+        return true
+      end
       load_workspace_classes_async
       load_workspace_functions_async
       load_workspace_types_async
@@ -226,5 +231,12 @@ module PuppetLanguageServer
       tempfile.delete if tempfile
     end
     private_class_method :with_temporary_file
+
+    def self.load_default_aggregate_async
+      @default_classes_loaded   = false if @default_classes_loaded.nil?
+      @default_functions_loaded = false if @default_functions_loaded.nil?
+      @default_types_loaded     = false if @default_types_loaded.nil?
+      sidecar_queue.enqueue('default_aggregate', [])
+    end
   end
 end

--- a/lib/puppet-languageserver/puppet_helper/cache.rb
+++ b/lib/puppet-languageserver/puppet_helper/cache.rb
@@ -12,6 +12,7 @@ module PuppetLanguageServer
       def import_sidecar_list!(list, section, origin = nil)
         section_object = section_to_object(section)
         return if section_object.nil?
+        list = [] if list.nil?
 
         @cache_lock.synchronize do
           # Remove the existing items

--- a/lib/puppet-languageserver/sidecar_protocol.rb
+++ b/lib/puppet-languageserver/sidecar_protocol.rb
@@ -385,6 +385,11 @@ module PuppetLanguageServer
           @aggregate[:types]
         end
 
+        def concat!(array)
+          return if array.nil? || array.empty?
+          array.each { |item| append!(item) }
+        end
+
         def append!(obj)
           list_for_object_class(obj.class) << obj
         end

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_puppetstrings/featureflag_puppetstrings_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_puppetstrings/featureflag_puppetstrings_spec.rb
@@ -111,14 +111,10 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings', :if => G
       deserial2 = PuppetLanguageServer::Sidecar::Protocol::AggregateMetadata.new()
       expect { deserial2.from_json!(result2) }.to_not raise_error
 
-      deserial.class
-              .instance_methods(false)
-              .reject { |name| %i[to_json from_json! each_list append!].include?(name) }
-              .each do |method_name|
-        # There should be at least one item
-        expect(deserial.send(method_name).count).to be > 0
-        # Before and after should be the same
-        expect_same_array_content(deserial.send(method_name), deserial2.send(method_name))
+      deserial.each_list do |key, value|
+        # There should be at least one item per list in the aggregate
+        expect(value.count).to be > 0
+        expect_same_array_content(value, deserial2.send(key))
       end
     end
   end
@@ -270,7 +266,7 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings', :if => G
     describe 'when running workspace_aggregate action' do
       let (:cmd_options) { ['--action', 'workspace_aggregate', '--local-workspace', workspace] }
 
-      it 'should return a cachable deserializable aggregate object with all default metadata' do
+      it 'should return a cachable deserializable aggregate object with all workspace metadata' do
         expect_empty_cache
 
         result = run_sidecar(cmd_options)
@@ -286,14 +282,10 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings', :if => G
         deserial2 = PuppetLanguageServer::Sidecar::Protocol::AggregateMetadata.new()
         expect { deserial2.from_json!(result2) }.to_not raise_error
 
-        deserial.class
-                .instance_methods(false)
-                .reject { |name| %i[to_json from_json! each_list append!].include?(name) }
-                .each do |method_name|
-          # There should be at least one item
-          expect(deserial.send(method_name).count).to be > 0
-          # Before and after should be the same
-          expect_same_array_content(deserial.send(method_name), deserial2.send(method_name))
+        deserial.each_list do |key, value|
+          # There should be at least one item per list in the aggregate
+          expect(value.count).to be > 0
+          expect_same_array_content(value, deserial2.send(key))
         end
       end
     end
@@ -429,14 +421,10 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings', :if => G
         deserial2 = PuppetLanguageServer::Sidecar::Protocol::AggregateMetadata.new()
         expect { deserial2.from_json!(result2) }.to_not raise_error
 
-        deserial.class
-                .instance_methods(false)
-                .reject { |name| %i[to_json from_json! each_list append!].include?(name) }
-                .each do |method_name|
-          # There should be at least one item
-          expect(deserial.send(method_name).count).to be > 0
-          # Before and after should be the same
-          expect_same_array_content(deserial.send(method_name), deserial2.send(method_name))
+        deserial.each_list do |key, value|
+          # There should be at least one item per list in the aggregate
+          expect(value.count).to be > 0
+          expect_same_array_content(value, deserial2.send(key))
         end
       end
     end

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/puppet-languageserver-sidecar_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/puppet-languageserver-sidecar_spec.rb
@@ -48,10 +48,17 @@ describe 'PuppetLanguageServerSidecar' do
   describe 'when running default_aggregate action' do
     let (:cmd_options) { ['--action', 'default_aggregate'] }
 
-    it 'should return an empty hash' do
+    it 'should return a deserializable aggregate object with all default metadata' do
       result = run_sidecar(cmd_options)
+      deserial = PuppetLanguageServer::Sidecar::Protocol::AggregateMetadata.new
+      expect { deserial.from_json!(result) }.to_not raise_error
 
-      expect(result).to eq('{}')
+      # The contents of the result are tested later
+
+      # There should be at least one item per list in the aggregate
+      deserial.each_list do |_, v|
+        expect(v.count).to be > 0
+      end
     end
   end
 
@@ -139,10 +146,17 @@ describe 'PuppetLanguageServerSidecar' do
     describe 'when running workspace_aggregate action' do
       let (:cmd_options) { ['--action', 'workspace_aggregate', '--local-workspace', workspace] }
 
-      it 'should return an empty hash' do
+      it 'should return a deserializable aggregate object with all workspace metadata' do
         result = run_sidecar(cmd_options)
+        deserial = PuppetLanguageServer::Sidecar::Protocol::AggregateMetadata.new
+        expect { deserial.from_json!(result) }.to_not raise_error
 
-        expect(result).to eq('{}')
+        # The contents of the result are tested later
+
+        # There should be at least one item per list in the aggregate
+        deserial.each_list do |_, v|
+          expect(v.count).to be > 0
+        end
       end
     end
 
@@ -235,10 +249,17 @@ describe 'PuppetLanguageServerSidecar' do
     describe 'when running workspace_aggregate action' do
       let (:cmd_options) { ['--action', 'workspace_aggregate', '--local-workspace', workspace] }
 
-      it 'should return an empty hash' do
+      it 'should return a deserializable aggregate object with all workspace metadata' do
         result = run_sidecar(cmd_options)
+        deserial = PuppetLanguageServer::Sidecar::Protocol::AggregateMetadata.new
+        expect { deserial.from_json!(result) }.to_not raise_error
 
-        expect(result).to eq('{}')
+        # The contents of the result are tested later
+
+        # There should be at least one item per list in the aggregate
+        deserial.each_list do |_, v|
+          expect(v.count).to be > 0
+        end
       end
     end
 

--- a/spec/languageserver/integration/puppet-languageserver/sidecar_queue_spec.rb
+++ b/spec/languageserver/integration/puppet-languageserver/sidecar_queue_spec.rb
@@ -62,6 +62,28 @@ describe 'sidecar_queue' do
   end
 
   describe '#execute_sync' do
+    context 'default_aggregate action' do
+      let(:action) { 'default_aggregate' }
+
+      it 'should deserialize the json, import into the cache and assert default classes are loaded' do
+        fixture = PuppetLanguageServer::Sidecar::Protocol::AggregateMetadata.new
+        fixture.append!(random_sidecar_puppet_class)
+        fixture.append!(random_sidecar_puppet_function)
+        fixture.append!(random_sidecar_puppet_type)
+        sidecar_response = [fixture.to_json, 'stderr', SuccessStatus.new]
+
+        expect(subject).to receive(:run_sidecar).and_return(sidecar_response)
+        expect(PuppetLanguageServer::PuppetHelper).to receive(:assert_default_classes_loaded)
+        expect(PuppetLanguageServer::PuppetHelper).to receive(:assert_default_functions_loaded)
+        expect(PuppetLanguageServer::PuppetHelper).to receive(:assert_default_types_loaded)
+
+        subject.execute_sync(action, [])
+        expect(cache.object_by_name(:class, fixture.classes[0].key)).to_not be_nil
+        expect(cache.object_by_name(:function, fixture.functions[0].key)).to_not be_nil
+        expect(cache.object_by_name(:type, fixture.types[0].key)).to_not be_nil
+      end
+    end
+
     context 'default_classes action' do
       let(:action) { 'default_classes' }
 


### PR DESCRIPTION
- [x] Lang server should use default_aggregate and workspace_aggregeate if the puppetstrings flag is set.

---

Previously the tests use private instance methods to verify the object, however
the each_list method now does that. This commit changes the tests to use this
method instead.

---

Previously the metadata aggregate action could only be used with the
puppetstrings feature flag.  However it is also very useful for normal operation.
This commit changes the action to be valid, and adds tests for this scenario.

---

This commit changes the language server to use the default and workspace
aggregate actions, but behind the puppetstrings feature.  There are no test
changes required.