### PR TITLE
(GH-170) Prepare for 0.21.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Unreleased
 
+## 0.21.0 - 2019-08-26
+
+### Added
+
+- ([GH-144](https://github.com/lingua-pupuli/puppet-editor-services/issues/144)) Add a Signature Helper Provider
+- ([GH-163](https://github.com/lingua-pupuli/puppet-editor-services/issues/163)) Add aggregate sidecar tasks
+
+### Fixed
+
+- ([GH-55](https://github.com/lingua-pupuli/puppet-editor-services/issues/55)) Debug Server is now supported on Puppet 6
+
+### Changed
+
+- ([GH-106](https://github.com/lingua-pupuli/puppet-editor-services/issues/106)) Update puppet-lint to 2.3.6
+- ([GH-167](https://github.com/lingua-pupuli/puppet-editor-services/issues/167)) Refactor Language Server inmemory caching
+
 ## 0.20.0 - 2019-07-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Appveyor Build status](https://ci.appveyor.com/api/projects/status/arryulh580j47u26?svg=true)](https://ci.appveyor.com/project/lingua-pupuli/puppet-editor-services) [![Travis Build Status](https://travis-ci.com/lingua-pupuli/puppet-editor-services.svg?branch=master)](https://travis-ci.com/lingua-pupuli/puppet-editor-services.svg?branch=master)
+[![Appveyor Build status](https://ci.appveyor.com/api/projects/status/arryulh580j47u26?svg=true)](https://ci.appveyor.com/project/lingua-pupuli/puppet-editor-services) [![Travis Build Status](https://travis-ci.com/lingua-pupuli/puppet-editor-services.svg?branch=master)](https://travis-ci.com/lingua-pupuli/puppet-editor-services)
 
 # Puppet Editor Services
 

--- a/lib/puppet-editor-services/version.rb
+++ b/lib/puppet-editor-services/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module PuppetEditorServices
-  PUPPETEDITORSERVICESVERSION = '0.20.0' unless defined? PUPPETEDITORSERVICESVERSION
+  PUPPETEDITORSERVICESVERSION = '0.21.0' unless defined? PUPPETEDITORSERVICESVERSION
 
   # @api public
   #


### PR DESCRIPTION
This commit updates the changelog and version for the 0.21.0 release.

This commit also updates the Travis CI link to go to Travis instead of the image.
