### PR TITLE
(GH-174) Understand Puppet Data Types

### DIFF
--- a/lib/puppet-languageserver/puppet_helper.rb
+++ b/lib/puppet-languageserver/puppet_helper.rb
@@ -166,6 +166,34 @@ module PuppetLanguageServer
       @inmemory_cache.object_names_by_section(:class).map(&:to_s)
     end
 
+    # DataTypes
+    def self.default_datatypes_loaded?
+      @default_datatypes_loaded.nil? ? false : @default_datatypes_loaded
+    end
+
+    def self.assert_default_datatypes_loaded
+      @default_datatypes_loaded = true
+    end
+
+    def self.load_default_datatypes
+      raise('Puppet Helper Cache has not been configured') if @inmemory_cache.nil?
+      @default_datatypes_loaded = false
+      sidecar_queue.execute_sync('default_datatypes', [])
+    end
+
+    def self.load_default_datatypes_async
+      raise('Puppet Helper Cache has not been configured') if @inmemory_cache.nil?
+      @default_datatypes_loaded = false
+      sidecar_queue.enqueue('default_datatypes', [])
+    end
+
+    def self.datatype(name)
+      return nil if @default_functions_loaded == false
+      raise('Puppet Helper Cache has not been configured') if @inmemory_cache.nil?
+      load_default_datatypes unless @default_functions_loaded
+      @inmemory_cache.object_by_name(:datatype, name)
+    end
+
     def self.cache
       raise('Puppet Helper Cache has not been configured') if @inmemory_cache.nil?
       @inmemory_cache

--- a/lib/puppet-languageserver/puppet_helper/cache.rb
+++ b/lib/puppet-languageserver/puppet_helper/cache.rb
@@ -3,7 +3,7 @@
 module PuppetLanguageServer
   module PuppetHelper
     class Cache
-      SECTIONS = %i[class type function].freeze
+      SECTIONS = %i[class type function datatype].freeze
       ORIGINS = %i[default workspace].freeze
 
       def initialize(_options = {})
@@ -35,7 +35,7 @@ module PuppetLanguageServer
         nil
       end
 
-      # section => <Type of object in the file :function, :type, :class>
+      # section => <Type of object in the file :function, :type, :class, :datatype>
       def object_by_name(section, name)
         name = name.intern if name.is_a?(String)
         return nil if section.nil?
@@ -50,7 +50,7 @@ module PuppetLanguageServer
         nil
       end
 
-      # section => <Type of object in the file :function, :type, :class>
+      # section => <Type of object in the file :function, :type, :class, :datatype>
       def object_names_by_section(section)
         result = []
         return result if section.nil?
@@ -64,7 +64,7 @@ module PuppetLanguageServer
         result.compact
       end
 
-      # section => <Type of object in the file :function, :type, :class>
+      # section => <Type of object in the file :function, :type, :class, :datatype>
       def objects_by_section(section, &_block)
         return if section.nil?
         @cache_lock.synchronize do

--- a/lib/puppet-languageserver/sidecar_protocol.rb
+++ b/lib/puppet-languageserver/sidecar_protocol.rb
@@ -195,6 +195,73 @@ module PuppetLanguageServer
         end
       end
 
+      class PuppetDataType < BasePuppetObject
+        attr_accessor :doc
+        attr_accessor :alias_of
+        attr_accessor :attributes
+        attr_accessor :is_type_alias
+
+        def initialize
+          super
+          self.attributes = PuppetDataTypeAttributeList.new
+        end
+
+        def to_h
+          super.to_h.merge(
+            'doc'           => doc,
+            'alias_of'      => alias_of,
+            'attributes'    => attributes.map(&:to_h),
+            'is_type_alias' => is_type_alias
+          )
+        end
+
+        def from_h!(value)
+          super
+
+          self.doc = value['doc']
+          self.alias_of = value['alias_of']
+          value['attributes'].each { |attr| attributes << PuppetDataTypeAttribute.new.from_h!(attr) } unless value['attributes'].nil?
+          self.is_type_alias = value['is_type_alias']
+          self
+        end
+      end
+
+      class PuppetDataTypeList < BasePuppetObjectList
+        def child_type
+          PuppetDataType
+        end
+      end
+
+      class PuppetDataTypeAttribute < BaseClass
+        attr_accessor :key
+        attr_accessor :doc
+        attr_accessor :default_value
+        attr_accessor :types
+
+        def to_h
+          {
+            'key'           => key,
+            'default_value' => default_value,
+            'doc'           => doc,
+            'types'         => types
+          }
+        end
+
+        def from_h!(value)
+          self.key           = value['key']
+          self.default_value = value['default_value']
+          self.doc           = value['doc']
+          self.types         = value['types']
+          self
+        end
+      end
+
+      class PuppetDataTypeAttributeList < BasePuppetObjectList
+        def child_type
+          PuppetDataTypeAttribute
+        end
+      end
+
       class PuppetFunction < BasePuppetObject
         attr_accessor :doc
         # The version of this function, typically 3 or 4.
@@ -377,6 +444,10 @@ module PuppetLanguageServer
           @aggregate[:classes]
         end
 
+        def datatypes
+          @aggregate[:datatypes]
+        end
+
         def functions
           @aggregate[:functions]
         end
@@ -423,6 +494,10 @@ module PuppetLanguageServer
           :classes   => {
             :item_class => PuppetClass,
             :list_class => PuppetClassList
+          },
+          :datatypes => {
+            :item_class => PuppetDataType,
+            :list_class => PuppetDataTypeList
           },
           :functions => {
             :item_class => PuppetFunction,

--- a/lib/puppet-languageserver/sidecar_queue.rb
+++ b/lib/puppet-languageserver/sidecar_queue.rb
@@ -66,12 +66,14 @@ module PuppetLanguageServer
       when 'default_aggregate'
         lists = PuppetLanguageServer::Sidecar::Protocol::AggregateMetadata.new.from_json!(result)
         @cache.import_sidecar_list!(lists.classes,   :class, :default)
+        @cache.import_sidecar_list!(lists.datatypes, :datatype, :default)
         @cache.import_sidecar_list!(lists.functions, :function, :default)
         @cache.import_sidecar_list!(lists.types,     :type, :default)
 
         PuppetLanguageServer::PuppetHelper.assert_default_classes_loaded
         PuppetLanguageServer::PuppetHelper.assert_default_functions_loaded
         PuppetLanguageServer::PuppetHelper.assert_default_types_loaded
+        PuppetLanguageServer::PuppetHelper.assert_default_datatypes_loaded
 
         lists.each_list do |k, v|
           if v.nil?
@@ -87,6 +89,13 @@ module PuppetLanguageServer
         PuppetLanguageServer.log_message(:debug, "SidecarQueue Thread: default_classes returned #{list.count} items")
 
         PuppetLanguageServer::PuppetHelper.assert_default_classes_loaded
+
+      when 'default_datatypes'
+        list = PuppetLanguageServer::Sidecar::Protocol::PuppetDataTypeList.new.from_json!(result)
+        @cache.import_sidecar_list!(list, :datatype, :default)
+        PuppetLanguageServer.log_message(:debug, "SidecarQueue Thread: default_datatypes returned #{list.count} items")
+
+        PuppetLanguageServer::PuppetHelper.assert_default_datatypes_loaded
 
       when 'default_functions'
         list = PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionList.new.from_json!(result)
@@ -111,6 +120,7 @@ module PuppetLanguageServer
       when 'workspace_aggregate'
         lists = PuppetLanguageServer::Sidecar::Protocol::AggregateMetadata.new.from_json!(result)
         @cache.import_sidecar_list!(lists.classes,   :class, :workspace)
+        @cache.import_sidecar_list!(lists.datatypes, :datatype, :workspace)
         @cache.import_sidecar_list!(lists.functions, :function, :workspace)
         @cache.import_sidecar_list!(lists.types,     :type, :workspace)
 
@@ -126,6 +136,11 @@ module PuppetLanguageServer
         list = PuppetLanguageServer::Sidecar::Protocol::PuppetClassList.new.from_json!(result)
         @cache.import_sidecar_list!(list, :class, :workspace)
         PuppetLanguageServer.log_message(:debug, "SidecarQueue Thread: workspace_classes returned #{list.count} items")
+
+      when 'workspace_datatypes'
+        list = PuppetLanguageServer::Sidecar::Protocol::PuppetDataTypeList.new.from_json!(result)
+        @cache.import_sidecar_list!(list, :datatype, :workspace)
+        PuppetLanguageServer.log_message(:debug, "SidecarQueue Thread: workspace_datatypes returned #{list.count} items")
 
       when 'workspace_functions'
         list = PuppetLanguageServer::Sidecar::Protocol::PuppetFunctionList.new.from_json!(result)

--- a/lib/puppet_languageserver.rb
+++ b/lib/puppet_languageserver.rb
@@ -259,6 +259,9 @@ module PuppetLanguageServer
 
         log_message(:info, 'Preloading Classes (Async)...')
         PuppetLanguageServer::PuppetHelper.load_default_classes_async
+
+        log_message(:info, 'Preloading DataTypes (Async)...')
+        PuppetLanguageServer::PuppetHelper.load_default_datatypes_async
       end
 
       if PuppetLanguageServer::DocumentStore.store_has_module_metadata? || PuppetLanguageServer::DocumentStore.store_has_environmentconf?

--- a/lib/puppet_languageserver_sidecar.rb
+++ b/lib/puppet_languageserver_sidecar.rb
@@ -107,12 +107,14 @@ module PuppetLanguageServerSidecar
     noop
     default_aggregate
     default_classes
+    default_datatypes
     default_functions
     default_types
     node_graph
     resource_list
     workspace_aggregate
     workspace_classes
+    workspace_datatypes
     workspace_functions
     workspace_types
   ].freeze
@@ -277,6 +279,14 @@ module PuppetLanguageServerSidecar
         PuppetLanguageServerSidecar::PuppetHelper.retrieve_classes(cache)
       end
 
+    when 'default_datatypes'
+      cache = options[:disable_cache] ? PuppetLanguageServerSidecar::Cache::Null.new : PuppetLanguageServerSidecar::Cache::FileSystem.new
+      if use_puppet_strings
+        PuppetLanguageServerSidecar::PuppetHelper.retrieve_via_puppet_strings(cache, :object_types => [:datatype]).datatypes
+      else
+        PuppetLanguageServer::Sidecar::Protocol::PuppetDataTypeList.new
+      end
+
     when 'default_functions'
       cache = options[:disable_cache] ? PuppetLanguageServerSidecar::Cache::Null.new : PuppetLanguageServerSidecar::Cache::FileSystem.new
       if use_puppet_strings
@@ -340,6 +350,17 @@ module PuppetLanguageServerSidecar
       else
         PuppetLanguageServerSidecar::PuppetHelper.retrieve_classes(null_cache,
                                                                    :root_path => PuppetLanguageServerSidecar::Workspace.root_path)
+      end
+
+    when 'workspace_datatypes'
+      return nil unless inject_workspace_as_module || inject_workspace_as_environment
+      if use_puppet_strings
+        cache = options[:disable_cache] ? PuppetLanguageServerSidecar::Cache::Null.new : PuppetLanguageServerSidecar::Cache::FileSystem.new
+        PuppetLanguageServerSidecar::PuppetHelper.retrieve_via_puppet_strings(cache,
+                                                                              :object_types => [:datatype],
+                                                                              :root_path    => PuppetLanguageServerSidecar::Workspace.root_path).datatypes
+      else
+        PuppetLanguageServer::Sidecar::Protocol::PuppetDataTypeList.new
       end
 
     when 'workspace_functions'

--- a/spec/languageserver-sidecar/fixtures/real_agent/cache/lib/puppet/datatypes/cachedatatype.rb
+++ b/spec/languageserver-sidecar/fixtures/real_agent/cache/lib/puppet/datatypes/cachedatatype.rb
@@ -1,0 +1,14 @@
+# An example Puppet Data Type in Ruby.
+#
+# @param arg1 [String[1]] A message parameter.
+# @param arg2 Optional String parameter. Defaults to 'param'.
+# @param badarg3 Optional String parameter. Defaults to 'param'.
+Puppet::DataTypes.create_type('RubyDataType') do
+  interface <<-PUPPET
+    attributes => {
+      arg1   => Numeric,
+      missingarg1   => { type => OString[1], value => "missing" },
+      arg2  => { type => Optional[String[1]], value => "param" }
+    }
+    PUPPET
+end

--- a/spec/languageserver-sidecar/fixtures/real_agent/environments/testfixtures/modules/defaultmodule/types/moduletypealias.pp
+++ b/spec/languageserver-sidecar/fixtures/real_agent/environments/testfixtures/modules/defaultmodule/types/moduletypealias.pp
@@ -1,0 +1,2 @@
+# Documentation for Defaultmodule Modultetypealias
+type Defaultmodule::Modultetypealias = Pattern[/^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/]

--- a/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/datatypes/profile_data_type.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/profile/lib/puppet/datatypes/profile_data_type.rb
@@ -1,0 +1,12 @@
+# A Puppet Data Type in Ruby.
+#
+# @param arg1 [String] A message parameter.
+# @param arg2 An Optional Numeric parameter.
+Puppet::DataTypes.create_type('ProfileDataType') do
+  interface <<-PUPPET
+    attributes => {
+      arg1  => { type => String, value => "defaultvalue" },
+      arg2  => { type => Optional[Numeric], value => 12 }
+    }
+    PUPPET
+end

--- a/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/role/types/testtype.pp
+++ b/spec/languageserver-sidecar/fixtures/valid_environment_workspace/site/role/types/testtype.pp
@@ -1,0 +1,2 @@
+# Documentation for Role::TestType
+type Role::TestType = Numeric

--- a/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/datatypes/valid_module_data_type.rb
+++ b/spec/languageserver-sidecar/fixtures/valid_module_workspace/lib/puppet/datatypes/valid_module_data_type.rb
@@ -1,0 +1,12 @@
+# A Puppet Data Type in Ruby.
+#
+# @param arg1 [String] A message parameter.
+# @param arg2 An Optional Numeric parameter.
+Puppet::DataTypes.create_type('ValidModuleDataType') do
+  interface <<-PUPPET
+    attributes => {
+      arg1  => { type => String, value => "defaultvalue" },
+      arg2  => { type => Optional[Numeric], value => 12 }
+    }
+    PUPPET
+end

--- a/spec/languageserver-sidecar/fixtures/valid_module_workspace/types/testtype.pp
+++ b/spec/languageserver-sidecar/fixtures/valid_module_workspace/types/testtype.pp
@@ -1,0 +1,2 @@
+# Documentation for Valid::TestType
+type Valid::TestType = String[2,20]

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_puppetstrings/puppet_strings_helper_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_puppetstrings/puppet_strings_helper_spec.rb
@@ -15,6 +15,69 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings' do
     let(:subject) { PuppetLanguageServerSidecar::PuppetStringsHelper::Helper.new }
     let(:cache) { nil }
 
+    # Data Types
+    context 'Given a Puppet Data Type' do
+      let(:fixture_filepath) { File.join($fixtures_dir, 'real_agent', 'cache', 'lib', 'puppet', 'datatypes', 'cachedatatype.rb') }
+
+      it 'should parse the file metadata correctly' do
+        result = subject.file_documentation(fixture_filepath, cache)
+        # There is only one datatype in the test fixture file
+        expect(result.datatypes.count).to eq(1)
+        item = result.datatypes[0]
+
+        # Check base methods
+        expect(item.key).to eq('RubyDataType')
+        expect(item.line).to eq(6)
+        expect(item.char).to be_nil
+        expect(item.length).to be_nil
+        expect(item.source).to eq(fixture_filepath)
+        # Check data type specific methods
+        expect(item.doc).to match(/An example Puppet Data Type in Ruby\./)
+        expect(item.is_type_alias).to eq(false)
+        expect(item.alias_of).to be_nil
+        expect(item.attributes.count).to eq(3)
+        attr = item.attributes[0]
+        expect(attr.key).to eq('arg1')
+        expect(attr.doc).to eq('A message parameter.')
+        expect(attr.default_value).to be_nil
+        expect(attr.types).to eq('Numeric')
+        attr = item.attributes[1]
+        expect(attr.key).to eq('arg2')
+        expect(attr.doc).to eq('Optional String parameter. Defaults to \'param\'.')
+        expect(attr.default_value).to eq('param')
+        expect(attr.types).to eq('Optional[String[1]]')
+        attr = item.attributes[2]
+        expect(attr.key).to eq('missingarg1')
+        expect(attr.doc).to eq('')
+        expect(attr.default_value).to eq('missing')
+        expect(attr.types).to eq('OString[1]')
+      end
+    end
+
+    context 'Given a Puppet Data Type Alias' do
+      let(:fixture_filepath) { File.join($fixtures_dir, 'real_agent', 'environments', 'testfixtures', 'modules', 'defaultmodule', 'types', 'moduletypealias.pp' ) }
+
+      it 'should parse the file metadata correctly' do
+        result = subject.file_documentation(fixture_filepath, cache)
+
+        # There is only one class in the test fixture file
+        expect(result.datatypes.count).to eq(1)
+        item = result.datatypes[0]
+
+        # Check base methods
+        expect(item.key).to eq('Defaultmodule::Modultetypealias')
+        expect(item.line).to eq(2)
+        expect(item.char).to be_nil
+        expect(item.length).to be_nil
+        expect(item.source).to eq(fixture_filepath)
+        # Check data type specific methods
+        expect(item.doc).to match(/Documentation for Defaultmodule Modultetypealias/)
+        expect(item.is_type_alias).to eq(true)
+        expect(item.alias_of).to eq('Pattern[/^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/]')
+        expect(item.attributes).to eq([])
+      end
+    end
+
     # Classes
     context 'Given a Puppet Class' do
       let(:fixture_filepath) { File.join($fixtures_dir, 'real_agent', 'environments', 'testfixtures', 'modules', 'defaultmodule', 'manifests', 'init.pp' ) }

--- a/spec/languageserver/spec_helper.rb
+++ b/spec/languageserver/spec_helper.rb
@@ -21,7 +21,8 @@ def wait_for_puppet_loading
   loop do
     break if PuppetLanguageServer::PuppetHelper.default_functions_loaded? &&
              PuppetLanguageServer::PuppetHelper.default_types_loaded? &&
-             PuppetLanguageServer::PuppetHelper.default_classes_loaded?
+             PuppetLanguageServer::PuppetHelper.default_classes_loaded? &&
+             PuppetLanguageServer::PuppetHelper.default_datatypes_loaded?
     sleep(1)
     interation += 1
     next if interation < 90
@@ -30,6 +31,7 @@ def wait_for_puppet_loading
             functions_loaded? = #{PuppetLanguageServer::PuppetHelper.default_functions_loaded?}
             types_loaded? = #{PuppetLanguageServer::PuppetHelper.default_types_loaded?}
             classes_loaded? = #{PuppetLanguageServer::PuppetHelper.default_classes_loaded?}
+            datatypes_loaded? = #{PuppetLanguageServer::PuppetHelper.default_datatypes_loaded?}
           ERRORMSG
   end
 end

--- a/spec/languageserver/spec_helper.rb
+++ b/spec/languageserver/spec_helper.rb
@@ -66,6 +66,25 @@ def random_sidecar_puppet_class(key = nil)
   result
 end
 
+def random_sidecar_puppet_datatype
+  result = add_random_basepuppetobject_values!(PuppetLanguageServer::Sidecar::Protocol::PuppetDataType.new())
+  result.doc = 'doc' + rand(1000).to_s
+  result.alias_of = "String[1, #{rand(255)}]"
+  result.attributes << random_sidecar_puppet_datatype_attribute
+  result.attributes << random_sidecar_puppet_datatype_attribute
+  result.attributes << random_sidecar_puppet_datatype_attribute
+  result.is_type_alias = rand(255) < 128
+  result
+end
+
+def random_sidecar_puppet_datatype_attribute
+  result = PuppetLanguageServer::Sidecar::Protocol::PuppetDataTypeAttribute.new
+  result.doc = 'doc' + rand(1000).to_s
+  result.default_value = 'default' + rand(1000).to_s
+  result.types = 'String'
+  result
+end
+
 def random_sidecar_puppet_function(key = nil)
   result = add_random_basepuppetobject_values!(PuppetLanguageServer::Sidecar::Protocol::PuppetFunction.new())
   result.key = key unless key.nil?


### PR DESCRIPTION
Fixes #174 

Now that Puppet Strings understands Puppet Data Types, the sidecar can be
modified to query for them.  This commit:

* Updates the Sidecar Protocol to add Puppet DataTypes and DataType aliases
* Adds two new actions default_datatypes and workspace_datatypes. Note that
  these will only be populated if the puppetstrings feature flag is set.
* Updates the Puppet Strings helper to extract the data type info from the YARD
  objects
* Updates the retrieve_via_puppet_strings method to also be able to extract
  Puppet Data Types.
* Unfortunately there is no way to enumerate all of the "core" data types.
  As a workaround, we _can_ query the type factory class and instantiate all of
  the types the factory can produce.  While not perfect, it's a very good start.

---

Now that the sidecar can understand datatypes, the Language Server needs to be
updated to query and cache the results.  This commit:

* Adds the default and workspace queries for data types
* Updates the default and workspace aggregrate queries to also query datatypes
* Updates server startup to query for data types on start
* Updates the puppet helper to handle datatype loading and querying.

---

Now that the langauge server understands data types, this commit updates the
Hover Provider to emit data type information, and tests for this feature.