### PR TITLE
(maint)(GH-169) Fixes to adhere to Language Server Protocol

### DIFF
--- a/lib/lsp/lsp_base.rb
+++ b/lib/lsp/lsp_base.rb
@@ -20,7 +20,8 @@ module LSP
         elsif !item_value.nil? && item_value.respond_to?(:to_h)
           item_value = item_value.to_h
         end
-        value[name.to_s] = item_value unless optional_names.include?(name) && item_value.nil?
+        valuename = name.to_s.end_with?('__lsp') ? name.to_s[0...-5] : name.to_s
+        value[valuename] = item_value unless optional_names.include?(name) && item_value.nil?
       end
 
       value

--- a/lib/lsp/lsp_protocol.rb
+++ b/lib/lsp/lsp_protocol.rb
@@ -25,7 +25,7 @@ module LSP
   # }
   class Registration < LSPBase
     attr_accessor :id # type: string
-    attr_accessor :method # type: string
+    attr_accessor :method__lsp # type: string
     attr_accessor :registerOptions # type: any
 
     def initialize(initial_hash = nil)
@@ -36,7 +36,7 @@ module LSP
     def from_h!(value)
       value = {} if value.nil?
       self.id = value['id']
-      self.method = value['method']
+      self.method__lsp = value['method']
       self.registerOptions = value['registerOptions']
       self
     end
@@ -68,12 +68,12 @@ module LSP
   # }
   class Unregistration < LSPBase
     attr_accessor :id # type: string
-    attr_accessor :method # type: string
+    attr_accessor :method__lsp # type: string
 
     def from_h!(value)
       value = {} if value.nil?
       self.id = value['id']
-      self.method = value['method']
+      self.method__lsp = value['method']
       self
     end
   end

--- a/lib/puppet-languageserver/message_router.rb
+++ b/lib/puppet-languageserver/message_router.rb
@@ -1,11 +1,35 @@
 # frozen_string_literal: true
 
 module PuppetLanguageServer
-  class MessageRouter
-    attr_reader :server_options
+  class BaseMessageRouter
     attr_accessor :json_rpc_handler
 
+    def initialize(*_); end
+
+    def receive_request(request)
+      if request.rpc_method.start_with?('$/')
+        json_rpc_handler.reply_error nil, PuppetLanguageServer::CODE_METHOD_NOT_FOUND, PuppetLanguageServer::MSG_METHOD_NOT_FOUND
+      else
+        PuppetLanguageServer.log_message(:error, "Unknown RPC method #{request.rpc_method}")
+      end
+    end
+
+    def receive_notification(method, _params)
+      if method.start_with?('$/')
+        PuppetLanguageServer.log_message(:debug, "Ignoring RPC notification #{method}")
+      else
+        PuppetLanguageServer.log_message(:error, "Unknown RPC notification #{method}")
+      end
+    end
+
+    def receive_response(_response, _original_request); end
+  end
+
+  class MessageRouter < BaseMessageRouter
+    attr_reader :server_options
+
     def initialize(options = {})
+      super
       @server_options = options.nil? ? {} : options
     end
 
@@ -21,7 +45,7 @@ module PuppetLanguageServer
         unless server_options[:puppet_version].nil? || server_options[:puppet_version] == Puppet.version
           # Add a minor delay before sending the notification to give the client some processing time
           sleep(0.5)
-          @json_rpc_handler.send_show_message_notification(
+          json_rpc_handler.send_show_message_notification(
             LSP::MessageType::WARNING,
             "Unable to use Puppet version '#{server_options[:puppet_version]}' as it is not available. Using version '#{Puppet.version}' instead."
           )
@@ -212,11 +236,7 @@ module PuppetLanguageServer
         end
 
       else
-        if request.rpc_method.start_with?('$/')
-          json_rpc_handler.reply_error nil, PuppetLanguageServer::CODE_METHOD_NOT_FOUND, PuppetLanguageServer::MSG_METHOD_NOT_FOUND
-        else
-          PuppetLanguageServer.log_message(:error, "Unknown RPC method #{request.rpc_method}")
-        end
+        super
       end
     rescue StandardError => e
       PuppetLanguageServer::CrashDump.write_crash_file(e, nil, 'request' => request.rpc_method, 'params' => request.params)
@@ -230,7 +250,7 @@ module PuppetLanguageServer
 
       when 'exit'
         PuppetLanguageServer.log_message(:info, 'Received exit notification.  Closing connection to client...')
-        @json_rpc_handler.close_connection
+        json_rpc_handler.close_connection
 
       when 'textDocument/didOpen'
         PuppetLanguageServer.log_message(:info, 'Received textDocument/didOpen notification.')
@@ -238,7 +258,7 @@ module PuppetLanguageServer
         content = params['textDocument']['text']
         doc_version = params['textDocument']['version']
         documents.set_document(file_uri, content, doc_version)
-        PuppetLanguageServer::ValidationQueue.enqueue(file_uri, doc_version, @json_rpc_handler)
+        PuppetLanguageServer::ValidationQueue.enqueue(file_uri, doc_version, json_rpc_handler)
 
       when 'textDocument/didClose'
         PuppetLanguageServer.log_message(:info, 'Received textDocument/didClose notification.')
@@ -251,7 +271,7 @@ module PuppetLanguageServer
         content = params['contentChanges'][0]['text'] # TODO: Bad hardcoding zero
         doc_version = params['textDocument']['version']
         documents.set_document(file_uri, content, doc_version)
-        PuppetLanguageServer::ValidationQueue.enqueue(file_uri, doc_version, @json_rpc_handler)
+        PuppetLanguageServer::ValidationQueue.enqueue(file_uri, doc_version, json_rpc_handler)
 
       when 'textDocument/didSave'
         PuppetLanguageServer.log_message(:info, 'Received textDocument/didSave notification.')
@@ -266,11 +286,7 @@ module PuppetLanguageServer
         end
 
       else
-        if method.start_with?('$/')
-          PuppetLanguageServer.log_message(:debug, "Ignoring RPC notification #{method}")
-        else
-          PuppetLanguageServer.log_message(:error, "Unknown RPC notification #{method}")
-        end
+        super
       end
     rescue StandardError => e
       PuppetLanguageServer::CrashDump.write_crash_file(e, nil, 'notification' => method, 'params' => params)
@@ -278,19 +294,14 @@ module PuppetLanguageServer
     end
 
     def receive_response(response, original_request)
-      # Do nothing
+      super
     rescue StandardError => e
       PuppetLanguageServer::CrashDump.write_crash_file(e, nil, 'response' => response, 'original_request' => original_request)
       raise
     end
   end
 
-  class DisabledMessageRouter
-    attr_accessor :json_rpc_handler
-
-    def initialize(_options)
-    end
-
+  class DisabledMessageRouter < BaseMessageRouter
     def receive_request(request)
       case request.rpc_method
       when 'initialize'
@@ -300,7 +311,7 @@ module PuppetLanguageServer
         request.reply_result('capabilities' => PuppetLanguageServer::ServerCapabilites.no_capabilities)
         # Add a minor delay before sending the notification to give the client some processing time
         sleep(0.5)
-        @json_rpc_handler.send_show_message_notification(
+        json_rpc_handler.send_show_message_notification(
           LSP::MessageType::WARNING,
           'An error occured while the Language Server was starting. The server has been disabled.'
         )
@@ -338,18 +349,14 @@ module PuppetLanguageServer
 
       when 'exit'
         PuppetLanguageServer.log_message(:info, 'Received exit notification.  Closing connection to client...')
-        @json_rpc_handler.close_connection
+        json_rpc_handler.close_connection
 
       else
-        PuppetLanguageServer.log_message(:error, "Unknown RPC notification #{method}")
+        super
       end
     rescue StandardError => e
       PuppetLanguageServer::CrashDump.write_crash_file(e, nil, 'notification' => method, 'params' => params)
       raise
-    end
-
-    def receive_response(_, _)
-      # Do nothing
     end
   end
 end

--- a/lib/puppet-languageserver/message_router.rb
+++ b/lib/puppet-languageserver/message_router.rb
@@ -212,7 +212,11 @@ module PuppetLanguageServer
         end
 
       else
-        PuppetLanguageServer.log_message(:error, "Unknown RPC method #{request.rpc_method}")
+        if request.rpc_method.start_with?('$/')
+          json_rpc_handler.reply_error nil, PuppetLanguageServer::CODE_METHOD_NOT_FOUND, PuppetLanguageServer::MSG_METHOD_NOT_FOUND
+        else
+          PuppetLanguageServer.log_message(:error, "Unknown RPC method #{request.rpc_method}")
+        end
       end
     rescue StandardError => e
       PuppetLanguageServer::CrashDump.write_crash_file(e, nil, 'request' => request.rpc_method, 'params' => request.params)
@@ -262,7 +266,11 @@ module PuppetLanguageServer
         end
 
       else
-        PuppetLanguageServer.log_message(:error, "Unknown RPC notification #{method}")
+        if method.start_with?('$/')
+          PuppetLanguageServer.log_message(:debug, "Ignoring RPC notification #{method}")
+        else
+          PuppetLanguageServer.log_message(:error, "Unknown RPC notification #{method}")
+        end
       end
     rescue StandardError => e
       PuppetLanguageServer::CrashDump.write_crash_file(e, nil, 'notification' => method, 'params' => params)

--- a/lib/puppet-languageserver/message_router.rb
+++ b/lib/puppet-languageserver/message_router.rb
@@ -268,6 +268,13 @@ module PuppetLanguageServer
       PuppetLanguageServer::CrashDump.write_crash_file(e, nil, 'notification' => method, 'params' => params)
       raise
     end
+
+    def receive_response(response, original_request)
+      # Do nothing
+    rescue StandardError => e
+      PuppetLanguageServer::CrashDump.write_crash_file(e, nil, 'response' => response, 'original_request' => original_request)
+      raise
+    end
   end
 
   class DisabledMessageRouter
@@ -331,6 +338,10 @@ module PuppetLanguageServer
     rescue StandardError => e
       PuppetLanguageServer::CrashDump.write_crash_file(e, nil, 'notification' => method, 'params' => params)
       raise
+    end
+
+    def receive_response(_, _)
+      # Do nothing
     end
   end
 end

--- a/spec/languageserver/spec_helper.rb
+++ b/spec/languageserver/spec_helper.rb
@@ -140,3 +140,15 @@ class MockRelationshipGraph
   def initialize()
   end
 end
+
+class MockMessageRouter
+  attr_accessor :json_rpc_handler
+
+  def initialize(_ = {}); end
+
+  def receive_request(_); end
+
+  def receive_notification(_, _); end
+
+  def receive_response(_, _); end
+end

--- a/spec/languageserver/unit/puppet-languageserver/json_rpc_handler_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/json_rpc_handler_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+describe 'PuppetLanguageServer::JSONRPCHandler' do
+  let(:connection) { MockConnection.new }
+  let(:message_router) { MockMessageRouter.new }
+  let(:subject_options) {{
+    connection: connection,
+    message_router: message_router
+  }}
+  let(:subject) { PuppetLanguageServer::JSONRPCHandler.new(subject_options) }
+
+  context 'Given a valid JSON Request string' do
+    let(:data) { "Content-Length: 67\r\n\r\n" + '{"jsonrpc":"2.0","id":1,"method":"puppet/getVersion","params":null}' }
+
+    it 'should call receive_request on the message router' do
+      expect(message_router).to receive(:receive_request)
+      subject.receive_data(data)
+    end
+  end
+
+  context 'Given a valid JSON Notification string' do
+    let(:data) { "Content-Length: 52\r\n\r\n" + '{"jsonrpc":"2.0","method":"initialized","params":{}}' }
+
+    it 'should call receive_notification on the message router' do
+      expect(message_router).to receive(:receive_notification)
+      subject.receive_data(data)
+    end
+  end
+
+  context 'Given a valid JSON Response string' do
+    let(:data) { "Content-Length: 57\r\n\r\n" + '{"jsonrpc":"2.0","id":1,"result":"success","params":null}' }
+
+    it 'should call receive_response on the message router' do
+      # Force the request id to what we want to test for.
+      allow(subject).to receive(:client_request_id!).and_return(1)
+      # Send a request to the client
+      subject.send_client_request('mock', {})
+      # Mimic a repsonse from the client
+      expect(message_router).to receive(:receive_response)
+      subject.receive_data(data)
+    end
+  end
+
+  context 'Given a JSON Response that has no matching request from the server' do
+    let(:data) { "Content-Length: 57\r\n\r\n" + '{"jsonrpc":"2.0","id":1,"result":"success","params":null}' }
+
+    it 'should ignore the response' do
+      expect(message_router).to_not receive(:receive_request)
+      expect(message_router).to_not receive(:receive_notification)
+      expect(message_router).to_not receive(:receive_response)
+      subject.receive_data(data)
+    end
+  end
+
+  context 'Given a JSON Response that appears twice' do
+    let(:data) { "Content-Length: 57\r\n\r\n" + '{"jsonrpc":"2.0","id":1,"result":"success","params":null}' }
+
+    it 'should call receive_response on the message router only once' do
+      # Force the request id to what we want to test for.
+      allow(subject).to receive(:client_request_id!).and_return(1)
+      # Send a request to the client
+      subject.send_client_request('mock', {})
+      # Mimic a repsonse from the client, only once
+      expect(message_router).to receive(:receive_response).once
+      expect(message_router).to_not receive(:receive_request)
+      expect(message_router).to_not receive(:receive_notification)
+      subject.receive_data(data)
+      subject.receive_data(data)
+    end
+  end
+end

--- a/spec/languageserver/unit/puppet-languageserver/message_router_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/message_router_spec.rb
@@ -51,6 +51,15 @@ describe 'message_router' do
       end
     end
 
+    context 'given a request that is protocol implementation dependant' do
+      let(:request_rpc_method) { '$/MockRequest' }
+
+      it 'should reply with an error' do
+        expect(subject.json_rpc_handler).to receive(:reply_error).with(Object, PuppetLanguageServer::CODE_METHOD_NOT_FOUND, Object)
+        subject.receive_request(request)
+      end
+    end
+
     # initialize - https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#initialize
     context 'given an initialize request' do
       let(:request_rpc_method) { 'initialize' }
@@ -809,6 +818,15 @@ describe 'message_router' do
       it 'should call PuppetLanguageServer::CrashDump.write_crash_file' do
         expect(PuppetLanguageServer::CrashDump).to receive(:write_crash_file)
         expect{ subject.receive_notification(notification_method, notification_params) }.to raise_error(/MockError/)
+      end
+    end
+
+    context 'given a notification that is protocol implementation dependant' do
+      let(:notification_method) { '$/MockNotification' }
+
+      it 'should log a debug message' do
+        expect(PuppetLanguageServer).to receive(:log_message).with(:debug, /Ignoring .+ #{Regexp.escape(notification_method)}/)
+        subject.receive_notification(notification_method, notification_params)
       end
     end
 

--- a/tools/lsp_introspect/index.js
+++ b/tools/lsp_introspect/index.js
@@ -227,7 +227,7 @@ function GenerateRubyEnums(enumList) {
       var rubyValue = enumType[enumItemName];
       switch (rubyValue.constructor.name) {
         case 'String':
-          rubyValue = "'" + rubyValue + "'.freeze"
+          rubyValue = "'" + rubyValue + "'"
           break;
         case 'Function':
           // Ignore function constants.
@@ -246,7 +246,8 @@ function GenerateRubyEnums(enumList) {
 }
 
 function GenerateRubyFileHeader(description) {
-  return "# DO NOT MODIFY. This file is built automatically\n# " + description + "\n\n" +
+  return "# frozen_string_literal: true\n\n" +
+         "# DO NOT MODIFY. This file is built automatically\n# " + description + "\n\n" +
          "# rubocop:disable Layout/EmptyLinesAroundClassBody\n" +
          "# rubocop:disable Lint/UselessAssignment\n" +
          "# rubocop:disable Style/AsciiComments\n" +


### PR DESCRIPTION
Fixes #169

Previously the LSP introspection tool used ruby frozen strings. However rubocop
prefers the `frozen_string_literal: true` header.  This commit changes the
introspection script and updates the lsp ruby files.

---

Previously the ruby classes created by the LSP introspection could create
methods which are reserved in ruby, but not JavaScript.  This commit modifies
the introspection tool to munge reserved method names with the suffix "__lsp"
so that they can still be used in ruby but the JSON serialisation and
deserialisation still work for the protocol.

---

Previously the JSON Handler could only handle LSP Notifications and Requests,
however the can also be a Server to Client Request Response workflow.

This commit:
* Updates the JSON Handler to record JSON requests from the server to the client.
* Updates the JSON Handler to route valid response to requests into the
  message router.
* Updates the Message Router to be able to receive Client Responses for
  processing.
* Adds tests to ensure that valid messages are routed in the message router
  appropriately.

---

Previously protocol implementation dependent messages (`$/`) were not being
handled correctly as per the LSP spec.  This commit:
* Updates the message router to respond with an error to unknown requests.
* Updates the message router to log a debug message for unknown notifications.
* Adds tests for these scenarios.

---

Previously the Message Router and Disabled Message Router had duplicate code.
This commit refactors the common logic into a base class.
