### PR TITLE
(maint) Send Language Server version in version request

### DIFF
--- a/lib/puppet-languageserver/message_router.rb
+++ b/lib/puppet-languageserver/message_router.rb
@@ -57,12 +57,13 @@ module PuppetLanguageServer
 
       when 'puppet/getVersion'
         request.reply_result(LSP::PuppetVersion.new(
-                               'puppetVersion'   => Puppet.version,
-                               'facterVersion'   => Facter.version,
-                               'factsLoaded'     => PuppetLanguageServer::FacterHelper.facts_loaded?,
-                               'functionsLoaded' => PuppetLanguageServer::PuppetHelper.default_functions_loaded?,
-                               'typesLoaded'     => PuppetLanguageServer::PuppetHelper.default_types_loaded?,
-                               'classesLoaded'   => PuppetLanguageServer::PuppetHelper.default_classes_loaded?
+                               'languageServerVersion' => PuppetEditorServices.version,
+                               'puppetVersion'         => Puppet.version,
+                               'facterVersion'         => Facter.version,
+                               'factsLoaded'           => PuppetLanguageServer::FacterHelper.facts_loaded?,
+                               'functionsLoaded'       => PuppetLanguageServer::PuppetHelper.default_functions_loaded?,
+                               'typesLoaded'           => PuppetLanguageServer::PuppetHelper.default_types_loaded?,
+                               'classesLoaded'         => PuppetLanguageServer::PuppetHelper.default_classes_loaded?
                              ))
 
       when 'puppet/getResource'

--- a/spec/languageserver/unit/puppet-languageserver/message_router_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/message_router_spec.rb
@@ -14,6 +14,10 @@ describe 'message_router' do
     result
   end
 
+  RSpec::Matchers.define :method_not_nil do |method_name|
+    match { |actual| !actual.send(method_name).nil? }
+  end
+
   describe '#documents' do
     it 'should respond to documents method' do
       expect(subject).to respond_to(:documents)
@@ -83,32 +87,32 @@ describe 'message_router' do
     context 'given a puppet/getVersion request' do
       let(:request_rpc_method) { 'puppet/getVersion' }
       it 'should reply with the Puppet Version' do
-        expect(request).to receive(:reply_result).with(duck_type(:puppetVersion))
+        expect(request).to receive(:reply_result).with(method_not_nil(:puppetVersion))
 
         subject.receive_request(request)
       end
       it 'should reply with the Facter Version' do
-        expect(request).to receive(:reply_result).with(duck_type(:facterVersion))
+        expect(request).to receive(:reply_result).with(method_not_nil(:facterVersion))
 
         subject.receive_request(request)
       end
       it 'should reply with the Language Server version' do
-        expect(request).to receive(:reply_result).with(duck_type(:languageServerVersion))
+        expect(request).to receive(:reply_result).with(method_not_nil(:languageServerVersion))
 
         subject.receive_request(request)
       end
       it 'should reply with whether the facts are loaded' do
-        expect(request).to receive(:reply_result).with(duck_type(:factsLoaded))
+        expect(request).to receive(:reply_result).with(method_not_nil(:factsLoaded))
 
         subject.receive_request(request)
       end
       it 'should reply with whether the functions are loaded' do
-        expect(request).to receive(:reply_result).with(duck_type(:functionsLoaded))
+        expect(request).to receive(:reply_result).with(method_not_nil(:functionsLoaded))
 
         subject.receive_request(request)
       end
       it 'should reply with whether the types are loaded' do
-        expect(request).to receive(:reply_result).with(duck_type(:typesLoaded))
+        expect(request).to receive(:reply_result).with(method_not_nil(:typesLoaded))
 
         subject.receive_request(request)
       end


### PR DESCRIPTION
Previously the Language Server Version was not being sent in the
puppet/getVersion custom request.  This commit adds the language server version
and adds tests to detect this in the future.
