### PR TITLE
(GH-177) Add registrations and settings for on type formatting

### DIFF
--- a/lib/puppet-languageserver/message_router.rb
+++ b/lib/puppet-languageserver/message_router.rb
@@ -34,7 +34,7 @@ module PuppetLanguageServer
     def initialize(options = {})
       super
       @server_options = options.nil? ? {} : options
-      @client = LanguageClient.new
+      @client = LanguageClient.new(self)
     end
 
     def documents
@@ -254,7 +254,7 @@ module PuppetLanguageServer
       when 'initialized'
         PuppetLanguageServer.log_message(:info, 'Client has received initialization')
         if client.client_capability('workspace', 'didChangeConfiguration', 'dynamicRegistration') == true
-          client.register_capability(self, 'workspace/didChangeConfiguration')
+          client.register_capability('workspace/didChangeConfiguration')
         else
           PuppetLanguageServer.log_message(:debug, 'Client does not support didChangeConfiguration dynamic registration. Using push method for configuration change detection.')
         end
@@ -300,7 +300,7 @@ module PuppetLanguageServer
         if params.key?('settings') && params['settings'].nil?
           # This is a notification from a dynamic registration.  Need to send a workspace/configuration
           # request to get the actual configuration
-          client.send_configuration_request(self)
+          client.send_configuration_request
         else
           client.parse_lsp_configuration_settings!(params['settings'])
         end
@@ -314,13 +314,13 @@ module PuppetLanguageServer
     end
 
     def receive_response(response, original_request)
-      unless receive_response_succesful?(response) # rubocop:disable Style/IfUnlessModifier Too long
+      unless receive_response_succesful?(response) # rubocop:disable Style/IfUnlessModifier Line is too long otherwise
         PuppetLanguageServer.log_message(:error, "Response for method '#{original_request['method']}' with id '#{original_request['id']}' failed with #{response['error']}")
       end
       # Error responses still need to be processed so process messages even if it failed
       case original_request['method']
       when 'client/registerCapability'
-        client.parse_register_capability_response!(self, response, original_request)
+        client.parse_register_capability_response!(response, original_request)
       when 'workspace/configuration'
         return unless receive_response_succesful?(response)
         client.parse_lsp_configuration_settings!(response['result'])

--- a/lib/puppet-languageserver/message_router.rb
+++ b/lib/puppet-languageserver/message_router.rb
@@ -321,6 +321,8 @@ module PuppetLanguageServer
       case original_request['method']
       when 'client/registerCapability'
         client.parse_register_capability_response!(response, original_request)
+      when 'client/unregisterCapability'
+        client.parse_unregister_capability_response!(response, original_request)
       when 'workspace/configuration'
         return unless receive_response_succesful?(response)
         client.parse_lsp_configuration_settings!(response['result'])

--- a/lib/puppet-languageserver/message_router.rb
+++ b/lib/puppet-languageserver/message_router.rb
@@ -46,7 +46,11 @@ module PuppetLanguageServer
       when 'initialize'
         PuppetLanguageServer.log_message(:debug, 'Received initialize method')
         client.parse_lsp_initialize!(request.params)
-        request.reply_result('capabilities' => PuppetLanguageServer::ServerCapabilites.capabilities)
+        # Setup static registrations if dynamic registration is not available
+        info = {
+          :documentOnTypeFormattingProvider => !client.client_capability('textDocument', 'onTypeFormatting', 'dynamicRegistration')
+        }
+        request.reply_result('capabilities' => PuppetLanguageServer::ServerCapabilites.capabilities(info))
 
       when 'shutdown'
         PuppetLanguageServer.log_message(:debug, 'Received shutdown method')
@@ -200,6 +204,9 @@ module PuppetLanguageServer
           PuppetLanguageServer.log_message(:error, "(textDocument/documentSymbol) #{e}")
           request.reply_result(nil)
         end
+
+      when 'textDocument/onTypeFormatting'
+        request.reply_result(nil)
 
       when 'textDocument/signatureHelp'
         file_uri = request.params['textDocument']['uri']

--- a/lib/puppet-languageserver/message_router.rb
+++ b/lib/puppet-languageserver/message_router.rb
@@ -325,7 +325,10 @@ module PuppetLanguageServer
         client.parse_unregister_capability_response!(response, original_request)
       when 'workspace/configuration'
         return unless receive_response_succesful?(response)
-        client.parse_lsp_configuration_settings!(response['result'])
+        original_request['params'].items.each_with_index do |item, index|
+          # The response from the client strips the section name so we need to re-add it
+          client.parse_lsp_configuration_settings!(item.section => response['result'][index])
+        end
       else
         super
       end

--- a/lib/puppet-languageserver/server_capabilities.rb
+++ b/lib/puppet-languageserver/server_capabilities.rb
@@ -2,10 +2,10 @@
 
 module PuppetLanguageServer
   module ServerCapabilites
-    def self.capabilities
+    def self.capabilities(options = {})
       # https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#initialize-request
 
-      {
+      value = {
         'textDocumentSync'        => LSP::TextDocumentSyncKind::FULL,
         'hoverProvider'           => true,
         'completionProvider'      => {
@@ -18,6 +18,14 @@ module PuppetLanguageServer
         'signatureHelpProvider'   => {
           'triggerCharacters' => ['(', ',']
         }
+      }
+      value['documentOnTypeFormattingProvider'] = document_on_type_formatting_options if options[:documentOnTypeFormattingProvider]
+      value
+    end
+
+    def self.document_on_type_formatting_options
+      {
+        'firstTriggerCharacter' => '>'
       }
     end
 

--- a/spec/languageserver/unit/puppet-languageserver/language_client_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/language_client_spec.rb
@@ -142,6 +142,10 @@ describe 'PuppetLanguageServer::LanguageClient' do
   let(:json_rpc_handler) { MockJSONRPCHandler.new }
   let(:message_router) { MockMessageRouter.new.tap { |i| i.json_rpc_handler = json_rpc_handler } }
 
+  before(:each) do
+    allow(PuppetLanguageServer).to receive(:log_message)
+  end
+
   describe '#client_capability' do
     before(:each) do
       subject.parse_lsp_initialize!(initialize_params)
@@ -180,6 +184,106 @@ describe 'PuppetLanguageServer::LanguageClient' do
     # TODO: Future use.
   end
 
+  describe '#capability_registrations' do
+    let(:method_name) { 'mockMethod' }
+    let(:method_options) { {} }
+    let(:request_id) { 'id001' }
+
+    it 'defaults to false' do
+      expect(subject.capability_registrations(method_name)).to eq([{:registered => false, :state => :complete}])
+    end
+
+    it 'should track the registration process as it completes succesfully' do
+      req_method_name = nil
+      req_method_params = nil
+      # Remember the registration so we can fake a response later
+      allow(json_rpc_handler).to receive(:send_client_request) do |n, p|
+        req_method_name = n
+        req_method_params = p
+      end
+      # Fake the request id
+      allow(subject).to receive(:new_request_id).and_return(request_id)
+
+      # Should start out not registered
+      expect(subject.capability_registrations(method_name)).to eq([{:registered => false, :state => :complete}])
+      # Send as registration request
+      subject.register_capability(message_router, method_name, method_options)
+      # Should show as in progress
+      expect(subject.capability_registrations(method_name)).to eq([{:registered => false, :state => :pending, :id => request_id}])
+      # Mock a valid response
+      response = { 'jsonrpc'=>'2.0', 'id'=> 0, 'result' => nil }
+      original_request = { 'jsonrpc'=>'2.0', 'id' => 0, 'method' => req_method_name, 'params' => req_method_params }
+      subject.parse_register_capability_response!(message_router, response, original_request)
+      # Should show registered
+      expect(subject.capability_registrations(method_name)).to eq([{:registered => true, :state => :complete, :id => request_id}])
+    end
+
+    it 'should track the registration process as it fails' do
+      req_method_name = nil
+      req_method_params = nil
+      # Remember the registration so we can fake a response later
+      allow(json_rpc_handler).to receive(:send_client_request) do |n, p|
+        req_method_name = n
+        req_method_params = p
+      end
+      # Fake the request id
+      allow(subject).to receive(:new_request_id).and_return(request_id)
+
+      # Should start out not registered
+      expect(subject.capability_registrations(method_name)).to eq([{:registered => false, :state => :complete}])
+      # Send as registration request
+      subject.register_capability(message_router, method_name, method_options)
+      # Should show as in progress
+      expect(subject.capability_registrations(method_name)).to eq([{:registered => false, :state => :pending, :id => request_id}])
+      # Mock an error response
+      response = { 'jsonrpc'=>'2.0', 'id'=> 0, 'error' => { 'code' => -1, 'message' => 'mock message' } }
+      original_request = { 'jsonrpc'=>'2.0', 'id' => 0, 'method' => req_method_name, 'params' => req_method_params }
+      subject.parse_register_capability_response!(message_router, response, original_request)
+      # Should show registered
+      expect(subject.capability_registrations(method_name)).to eq([{:registered => false, :state => :complete, :id => request_id}])
+    end
+
+    it 'should preserve the registration state until it is completed' do
+      req_method_name = nil
+      req_method_params = nil
+      # Remember the registration so we can fake a response later
+      allow(json_rpc_handler).to receive(:send_client_request) do |n, p|
+        req_method_name = n
+        req_method_params = p
+      end
+      # Fake the request id
+      request_id2 = 'id002'
+      allow(subject).to receive(:new_request_id).and_return(request_id, request_id2)
+
+      # Should start out not registered
+      expect(subject.capability_registrations(method_name)).to eq([{:registered => false, :state => :complete}])
+      # Send as registration request
+      subject.register_capability(message_router, method_name, method_options)
+      # Mock a valid response
+      response = { 'jsonrpc'=>'2.0', 'id'=> 0, 'result' => nil }
+      original_request = { 'jsonrpc'=>'2.0', 'id' => 0, 'method' => req_method_name, 'params' => req_method_params }
+      subject.parse_register_capability_response!(message_router, response, original_request)
+      # Should show registered
+      expect(subject.capability_registrations(method_name)).to eq([{:registered => true, :state => :complete, :id => request_id}])
+      # Send another registration request
+      subject.register_capability(message_router, method_name, method_options)
+      # Should show as in progress
+      expect(subject.capability_registrations(method_name)).to eq([
+        {:registered => true,  :state => :complete, :id => request_id},
+        {:registered => false, :state => :pending,  :id => request_id2}
+      ])
+      # Mock an error response
+      response = { 'jsonrpc'=>'2.0', 'id'=> 0, 'error' => { 'code' => -1, 'message' => 'mock message' } }
+      original_request = { 'jsonrpc'=>'2.0', 'id' => 0, 'method' => req_method_name, 'params' => req_method_params }
+      subject.parse_register_capability_response!(message_router, response, original_request)
+      # Should still show registered
+      expect(subject.capability_registrations(method_name)).to eq([
+        {:registered => true,  :state => :complete, :id => request_id},
+        {:registered => false, :state => :complete,  :id => request_id2}
+      ])
+    end
+  end
+
   describe '#register_capability' do
     let(:method_name) { 'mockMethod' }
     let(:method_options) { {} }
@@ -197,6 +301,33 @@ describe 'PuppetLanguageServer::LanguageClient' do
     it 'should include the parameters to register' do
       subject.register_capability(message_router, method_name, method_options)
       expect(json_rpc_handler.connection.buffer).to include('"registerOptions":{}')
+    end
+
+    it 'should log a message if a registration is already in progress' do
+      allow(json_rpc_handler).to receive(:send_client_request)
+      expect(PuppetLanguageServer).to receive(:log_message).with(:warn, /#{method_name}/)
+
+      subject.register_capability(message_router, method_name, method_options)
+      subject.register_capability(message_router, method_name, method_options)
+    end
+
+    it 'should not log a message if a previous registration completed' do
+      method_name = nil
+      method_params = nil
+      # Remember the registration so we can fake a response later
+      allow(json_rpc_handler).to receive(:send_client_request) do |n, p|
+        method_name = n
+        method_params = p
+      end
+      expect(PuppetLanguageServer).to_not receive(:log_message).with(:warn, /#{method_name}/)
+      # Send as registration request
+      subject.register_capability(message_router, method_name, method_options)
+      # Mock a valid response
+      response = { 'jsonrpc'=>'2.0', 'id'=> 0, 'result' => nil }
+      original_request = { 'jsonrpc'=>'2.0', 'id' => 0, 'method' => method_name, 'params' => method_params }
+      subject.parse_register_capability_response!(message_router, response, original_request)
+
+      subject.register_capability(message_router, method_name, method_options)
     end
   end
 
@@ -237,11 +368,25 @@ describe 'PuppetLanguageServer::LanguageClient' do
         params
       end
 
-      it 'should log the registration' do
-        allow(PuppetLanguageServer).to receive(:log_message)
-        expect(PuppetLanguageServer).to receive(:log_message).with(:info, /validMethod/)
+      context 'that failed' do
+        before(:each) do
+          response.delete('result') if response.key?('result')
+          response['error'] = { 'code' => -1, 'message' => 'mock message' }
+        end
 
-        subject.parse_register_capability_response!(message_router, response, original_request)
+        it 'should not log the registration' do
+          expect(PuppetLanguageServer).to_not receive(:log_message).with(:info, /validMethod/)
+
+          subject.parse_register_capability_response!(message_router, response, original_request)
+        end
+      end
+
+      context 'that succeeded' do
+        it 'should log the registration' do
+          expect(PuppetLanguageServer).to receive(:log_message).with(:info, /validMethod/)
+
+          subject.parse_register_capability_response!(message_router, response, original_request)
+        end
       end
     end
   end

--- a/spec/languageserver/unit/puppet-languageserver/message_router_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/message_router_spec.rb
@@ -858,7 +858,7 @@ describe 'message_router' do
         end
 
         it 'should attempt to register workspace/didChangeConfiguration' do
-          expect(subject.client).to receive(:register_capability).with(Object, 'workspace/didChangeConfiguration')
+          expect(subject.client).to receive(:register_capability).with('workspace/didChangeConfiguration')
 
           subject.receive_notification(notification_method, notification_params)
         end
@@ -1037,7 +1037,7 @@ describe 'message_router' do
         let(:config_settings) { nil }
 
         it 'should send a configuration request' do
-          expect(subject.client).to receive(:send_configuration_request).with(Object)
+          expect(subject.client).to receive(:send_configuration_request).with(no_args)
 
           subject.receive_notification(notification_method, notification_params)
         end
@@ -1116,7 +1116,7 @@ describe 'message_router' do
       let(:request_params) { {} }
 
       it 'should call client.parse_register_capability_response!' do
-        expect(subject.client).to receive(:parse_register_capability_response!).with(Object, response, original_request)
+        expect(subject.client).to receive(:parse_register_capability_response!).with(response, original_request)
 
         subject.receive_response(response, original_request)
       end

--- a/spec/languageserver/unit/puppet-languageserver/message_router_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/message_router_spec.rb
@@ -1123,12 +1123,16 @@ describe 'message_router' do
     end
 
     context 'given an original workspace/configuration request' do
-      let(:response_result) { { 'setting1' => 'value1' } }
+      let(:response_result) { [{ 'setting1' => 'value1' }] }
       let(:request_method) { 'workspace/configuration'}
-      let(:request_params) { {} }
+      let(:request_params) do
+        params = LSP::ConfigurationParams.new.from_h!('items' => [])
+        params.items << LSP::ConfigurationItem.new.from_h!('section' => 'mock')
+        params
+      end
 
       it 'should call client.parse_lsp_configuration_settings!' do
-        expect(subject.client).to receive(:parse_lsp_configuration_settings!).with(response_result)
+        expect(subject.client).to receive(:parse_lsp_configuration_settings!).with({ 'mock' => response_result[0] })
 
         subject.receive_response(response, original_request)
       end


### PR DESCRIPTION
Part of the work for #177 

Builds on #184

---

Previously the settings were passed directly from the response into the
client for processing however this does not emulate the legacy settings hash.

This commit adds the original scope onto the settings hash so it appears like
the legacy hash e.g. puppet.editorservices.abc instead of editorserivces.abc

---

While technically the protocol does allow the server to send window/showMessage
notifcations during initialization, it's better to send the warning at the
end of initialization i.e. at the initialized notification.
9d13ba8

---

Now that the Language Client can process client settings, and dynamic
registrations it is now possible to setup the server to register to receive the
onTypeFormatting request.  This commit:

* Responds to the 'puppet.editorService.formatOnType.enable' client setting
* Dynamically registers the provider if dynamic registration is possible
  otherwise uses static registration
* Adds a format_on_type method on the Language Client to track whether this
  feature is enabled
* Adds dummy response to the `textDocument/onTypeFormatting` request
* Adds tests for the client interacting with the settings
