### PR TITLE
(GH-177) Add auto-align hash rocket feature

### DIFF
--- a/lib/puppet-languageserver/manifest/format_on_type_provider.rb
+++ b/lib/puppet-languageserver/manifest/format_on_type_provider.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require 'puppet-lint'
+
+module PuppetLanguageServer
+  module Manifest
+    class FormatOnTypeProvider
+      class << self
+        def instance
+          @instance ||= new
+        end
+      end
+
+      def format(content, line, char, trigger_character, formatting_options)
+        result = []
+        # Abort if the user has pressed something other than `>`
+        return result unless trigger_character == '>'
+        # Abort if the formatting is tab based. Can't do that yet
+        return result unless formatting_options['insertSpaces'] == true
+        # Abort if content is too big
+        return result if content.length > 4096
+
+        lexer = PuppetLint::Lexer.new
+        tokens = lexer.tokenise(content)
+
+        # Find where in the manifest the cursor is
+        cursor_token = find_token_by_location(tokens, line, char)
+        return result if cursor_token.nil?
+        # The cursor should be at the end of a hashrocket, otherwise exit
+        return result unless cursor_token.type == :FARROW
+
+        # Find the start of the hash with respect to the cursor
+        start_brace = cursor_token.prev_token_of(:LBRACE, skip_blocks: true)
+        # Find the end  of the hash with respect to the cursor
+        end_brace = cursor_token.next_token_of(:RBRACE, skip_blocks: true)
+
+        # The line count between the start and end brace needs to be at least 2 lines. Otherwise there's nothing to align to
+        return result if end_brace.nil? || start_brace.nil? || end_brace.line - start_brace.line <= 2
+
+        # Find all hashrockets '=>' between the hash braces, ignoring nested hashes
+        farrows = []
+        farrow_token = start_brace
+        lines = []
+        loop do
+          farrow_token = farrow_token.next_token_of(:FARROW, skip_blocks: true)
+          # if there are no more hashrockets, or we've gone past the end_brace, we can exit the loop
+          break if farrow_token.nil? || farrow_token.line > end_brace.line
+          # if there's a hashrocket AFTER the closing brace (why?) then we can also exit the loop
+          break if farrow_token.line == end_brace.line && farrow_token.character > end_brace.character
+          # Check for multiple hashrockets on the same line. If we find some, then we can't do any automated indentation
+          return result if lines.include?(farrow_token.line)
+          lines << farrow_token.line
+          farrows << { token: farrow_token }
+        end
+
+        # Now we have a list of farrows, time for figure out the indentation marks
+        farrows.each do |item|
+          item.merge!(calculate_indentation_info(item[:token]))
+        end
+
+        # Now we have the list of indentations we can find the biggest
+        max_indent = -1
+        farrows.each do |info|
+          max_indent = info[:indent] if info[:indent] > max_indent
+        end
+        # No valid indentations found
+        return result if max_indent == -1
+
+        # Now we have the indent size, generate all of the required TextEdits
+        farrows.each do |info|
+          # Ignore invalid hashrockets
+          next if info[:indent] == -1
+          end_name_token = info[:name_token].column + info[:name_token].to_manifest.length
+          begin_farrow_token = info[:token].column
+          new_whitespace = max_indent - end_name_token
+          # If the whitespace is already what we want, then ignore it.
+          next if begin_farrow_token - end_name_token == new_whitespace
+
+          # Create the TextEdit
+          result << LSP::TextEdit.new.from_h!(
+            'newText' => ' ' * new_whitespace,
+            'range'   => LSP.create_range(info[:token].line - 1, end_name_token - 1, info[:token].line - 1, begin_farrow_token - 1)
+          )
+        end
+        result
+      end
+
+      private
+
+      VALID_TOKEN_TYPES = %i[NAME STRING SSTRING].freeze
+
+      def find_token_by_location(tokens, line, character)
+        return nil if tokens.empty?
+        # Puppet Lint uses base 1, but LSP is base 0, so adjust accordingly
+        cursor_line = line + 1
+        cursor_column = character + 1
+        idx = -1
+        while idx < tokens.count
+          idx += 1
+          # if the token is on previous lines keep looking...
+          next if tokens[idx].line < cursor_line
+          # return nil if we skipped over the line we need
+          return nil if tokens[idx].line > cursor_line
+          # return nil if we skipped over the character position we need
+          return nil if tokens[idx].column > cursor_column
+          # return the token if it starts on the cursor column we are interested in
+          return tokens[idx] if tokens[idx].column == cursor_column
+          end_column = tokens[idx].column + tokens[idx].to_manifest.length
+          # return the token it the cursor column is within the token string
+          return tokens[idx] if cursor_column <= end_column
+          # otherwise, keep on searching
+        end
+        nil
+      end
+
+      def calculate_indentation_info(farrow_token)
+        result = { indent: -1 }
+        # This is not a valid hashrocket if there's no previous tokens
+        return result if farrow_token.prev_token.nil?
+        if VALID_TOKEN_TYPES.include?(farrow_token.prev_token.type)
+          # Someone forgot the whitespace! e.g. ensure=>
+          result[:indent] = farrow_token.column + 1
+          result[:name_token] = farrow_token.prev_token
+          return result
+        end
+        if farrow_token.prev_token.type == :WHITESPACE
+          # If the whitespace has no previous token (which shouldn't happen) or the thing before the whitespace is not a property name this it not a valid hashrocket
+          return result if farrow_token.prev_token.prev_token.nil?
+          return result unless VALID_TOKEN_TYPES.include?(farrow_token.prev_token.prev_token.type)
+          result[:name_token] = farrow_token.prev_token.prev_token
+          result[:indent] = farrow_token.prev_token.column + 1 # The indent is the whitespace column + 1
+        end
+        result
+      end
+    end
+  end
+end

--- a/lib/puppet-languageserver/message_router.rb
+++ b/lib/puppet-languageserver/message_router.rb
@@ -34,7 +34,7 @@ module PuppetLanguageServer
     def initialize(options = {})
       super
       @server_options = options.nil? ? {} : options
-      @client = LanguageClient.new
+      @client = LanguageClient.new(self)
     end
 
     def documents
@@ -254,7 +254,7 @@ module PuppetLanguageServer
       when 'initialized'
         PuppetLanguageServer.log_message(:info, 'Client has received initialization')
         if client.client_capability('workspace', 'didChangeConfiguration', 'dynamicRegistration') == true
-          client.register_capability(self, 'workspace/didChangeConfiguration')
+          client.register_capability('workspace/didChangeConfiguration')
         else
           PuppetLanguageServer.log_message(:debug, 'Client does not support didChangeConfiguration dynamic registration. Using push method for configuration change detection.')
         end
@@ -300,7 +300,7 @@ module PuppetLanguageServer
         if params.key?('settings') && params['settings'].nil?
           # This is a notification from a dynamic registration.  Need to send a workspace/configuration
           # request to get the actual configuration
-          client.send_configuration_request(self)
+          client.send_configuration_request
         else
           client.parse_lsp_configuration_settings!(params['settings'])
         end
@@ -314,13 +314,13 @@ module PuppetLanguageServer
     end
 
     def receive_response(response, original_request)
-      unless receive_response_succesful?(response) # rubocop:disable Style/IfUnlessModifier Too long
+      unless receive_response_succesful?(response) # rubocop:disable Style/IfUnlessModifier Line is too long otherwise
         PuppetLanguageServer.log_message(:error, "Response for method '#{original_request['method']}' with id '#{original_request['id']}' failed with #{response['error']}")
       end
       # Error responses still need to be processed so process messages even if it failed
       case original_request['method']
       when 'client/registerCapability'
-        client.parse_register_capability_response!(self, response, original_request)
+        client.parse_register_capability_response!(response, original_request)
       when 'workspace/configuration'
         return unless receive_response_succesful?(response)
         client.parse_lsp_configuration_settings!(response['result'])

--- a/lib/puppet-languageserver/message_router.rb
+++ b/lib/puppet-languageserver/message_router.rb
@@ -321,6 +321,8 @@ module PuppetLanguageServer
       case original_request['method']
       when 'client/registerCapability'
         client.parse_register_capability_response!(response, original_request)
+      when 'client/unregisterCapability'
+        client.parse_unregister_capability_response!(response, original_request)
       when 'workspace/configuration'
         return unless receive_response_succesful?(response)
         client.parse_lsp_configuration_settings!(response['result'])

--- a/lib/puppet-languageserver/message_router.rb
+++ b/lib/puppet-languageserver/message_router.rb
@@ -46,7 +46,11 @@ module PuppetLanguageServer
       when 'initialize'
         PuppetLanguageServer.log_message(:debug, 'Received initialize method')
         client.parse_lsp_initialize!(request.params)
-        request.reply_result('capabilities' => PuppetLanguageServer::ServerCapabilites.capabilities)
+        # Setup static registrations if dynamic registration is not available
+        info = {
+          :documentOnTypeFormattingProvider => !client.client_capability('textDocument', 'onTypeFormatting', 'dynamicRegistration')
+        }
+        request.reply_result('capabilities' => PuppetLanguageServer::ServerCapabilites.capabilities(info))
 
       when 'shutdown'
         PuppetLanguageServer.log_message(:debug, 'Received shutdown method')
@@ -200,6 +204,9 @@ module PuppetLanguageServer
           PuppetLanguageServer.log_message(:error, "(textDocument/documentSymbol) #{e}")
           request.reply_result(nil)
         end
+
+      when 'textDocument/onTypeFormatting'
+        request.reply_result(nil)
 
       when 'textDocument/signatureHelp'
         file_uri = request.params['textDocument']['uri']

--- a/lib/puppet-languageserver/message_router.rb
+++ b/lib/puppet-languageserver/message_router.rb
@@ -325,7 +325,10 @@ module PuppetLanguageServer
         client.parse_unregister_capability_response!(response, original_request)
       when 'workspace/configuration'
         return unless receive_response_succesful?(response)
-        client.parse_lsp_configuration_settings!(response['result'])
+        original_request['params'].items.each_with_index do |item, index|
+          # The response from the client strips the section name so we need to re-add it
+          client.parse_lsp_configuration_settings!(item.section => response['result'][index])
+        end
       else
         super
       end

--- a/lib/puppet-languageserver/message_router.rb
+++ b/lib/puppet-languageserver/message_router.rb
@@ -206,7 +206,31 @@ module PuppetLanguageServer
         end
 
       when 'textDocument/onTypeFormatting'
-        request.reply_result(nil)
+        unless client.format_on_type
+          request.reply_result(nil)
+          return
+        end
+        file_uri = request.params['textDocument']['uri']
+        line_num = request.params['position']['line']
+        char_num = request.params['position']['character']
+        content  = documents.document(file_uri)
+        begin
+          case documents.document_type(file_uri)
+          when :manifest
+            request.reply_result(PuppetLanguageServer::Manifest::FormatOnTypeProvider.instance.format(
+                                   content,
+                                   line_num,
+                                   char_num,
+                                   request.params['ch'],
+                                   request.params['options']
+                                 ))
+          else
+            raise "Unable to format on type on #{file_uri}"
+          end
+        rescue StandardError => e
+          PuppetLanguageServer.log_message(:error, "(textDocument/onTypeFormatting) #{e}")
+          request.reply_result(nil)
+        end
 
       when 'textDocument/signatureHelp'
         file_uri = request.params['textDocument']['uri']

--- a/lib/puppet-languageserver/providers.rb
+++ b/lib/puppet-languageserver/providers.rb
@@ -5,6 +5,7 @@
   manifest/completion_provider
   manifest/definition_provider
   manifest/document_symbol_provider
+  manifest/format_on_type_provider
   manifest/signature_provider
   manifest/validation_provider
   manifest/hover_provider

--- a/lib/puppet-languageserver/server_capabilities.rb
+++ b/lib/puppet-languageserver/server_capabilities.rb
@@ -2,10 +2,10 @@
 
 module PuppetLanguageServer
   module ServerCapabilites
-    def self.capabilities
+    def self.capabilities(options = {})
       # https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#initialize-request
 
-      {
+      value = {
         'textDocumentSync'        => LSP::TextDocumentSyncKind::FULL,
         'hoverProvider'           => true,
         'completionProvider'      => {
@@ -18,6 +18,14 @@ module PuppetLanguageServer
         'signatureHelpProvider'   => {
           'triggerCharacters' => ['(', ',']
         }
+      }
+      value['documentOnTypeFormattingProvider'] = document_on_type_formatting_options if options[:documentOnTypeFormattingProvider]
+      value
+    end
+
+    def self.document_on_type_formatting_options
+      {
+        'firstTriggerCharacter' => '>'
       }
     end
 

--- a/spec/languageserver/unit/puppet-languageserver/language_client_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/language_client_spec.rb
@@ -142,6 +142,10 @@ describe 'PuppetLanguageServer::LanguageClient' do
   let(:json_rpc_handler) { MockJSONRPCHandler.new }
   let(:message_router) { MockMessageRouter.new.tap { |i| i.json_rpc_handler = json_rpc_handler } }
 
+  before(:each) do
+    allow(PuppetLanguageServer).to receive(:log_message)
+  end
+
   describe '#client_capability' do
     before(:each) do
       subject.parse_lsp_initialize!(initialize_params)
@@ -180,6 +184,106 @@ describe 'PuppetLanguageServer::LanguageClient' do
     # TODO: Future use.
   end
 
+  describe '#capability_registrations' do
+    let(:method_name) { 'mockMethod' }
+    let(:method_options) { {} }
+    let(:request_id) { 'id001' }
+
+    it 'defaults to false' do
+      expect(subject.capability_registrations(method_name)).to eq([{:registered => false, :state => :complete}])
+    end
+
+    it 'should track the registration process as it completes succesfully' do
+      req_method_name = nil
+      req_method_params = nil
+      # Remember the registration so we can fake a response later
+      allow(json_rpc_handler).to receive(:send_client_request) do |n, p|
+        req_method_name = n
+        req_method_params = p
+      end
+      # Fake the request id
+      allow(subject).to receive(:new_request_id).and_return(request_id)
+
+      # Should start out not registered
+      expect(subject.capability_registrations(method_name)).to eq([{:registered => false, :state => :complete}])
+      # Send as registration request
+      subject.register_capability(message_router, method_name, method_options)
+      # Should show as in progress
+      expect(subject.capability_registrations(method_name)).to eq([{:registered => false, :state => :pending, :id => request_id}])
+      # Mock a valid response
+      response = { 'jsonrpc'=>'2.0', 'id'=> 0, 'result' => nil }
+      original_request = { 'jsonrpc'=>'2.0', 'id' => 0, 'method' => req_method_name, 'params' => req_method_params }
+      subject.parse_register_capability_response!(message_router, response, original_request)
+      # Should show registered
+      expect(subject.capability_registrations(method_name)).to eq([{:registered => true, :state => :complete, :id => request_id}])
+    end
+
+    it 'should track the registration process as it fails' do
+      req_method_name = nil
+      req_method_params = nil
+      # Remember the registration so we can fake a response later
+      allow(json_rpc_handler).to receive(:send_client_request) do |n, p|
+        req_method_name = n
+        req_method_params = p
+      end
+      # Fake the request id
+      allow(subject).to receive(:new_request_id).and_return(request_id)
+
+      # Should start out not registered
+      expect(subject.capability_registrations(method_name)).to eq([{:registered => false, :state => :complete}])
+      # Send as registration request
+      subject.register_capability(message_router, method_name, method_options)
+      # Should show as in progress
+      expect(subject.capability_registrations(method_name)).to eq([{:registered => false, :state => :pending, :id => request_id}])
+      # Mock an error response
+      response = { 'jsonrpc'=>'2.0', 'id'=> 0, 'error' => { 'code' => -1, 'message' => 'mock message' } }
+      original_request = { 'jsonrpc'=>'2.0', 'id' => 0, 'method' => req_method_name, 'params' => req_method_params }
+      subject.parse_register_capability_response!(message_router, response, original_request)
+      # Should show registered
+      expect(subject.capability_registrations(method_name)).to eq([{:registered => false, :state => :complete, :id => request_id}])
+    end
+
+    it 'should preserve the registration state until it is completed' do
+      req_method_name = nil
+      req_method_params = nil
+      # Remember the registration so we can fake a response later
+      allow(json_rpc_handler).to receive(:send_client_request) do |n, p|
+        req_method_name = n
+        req_method_params = p
+      end
+      # Fake the request id
+      request_id2 = 'id002'
+      allow(subject).to receive(:new_request_id).and_return(request_id, request_id2)
+
+      # Should start out not registered
+      expect(subject.capability_registrations(method_name)).to eq([{:registered => false, :state => :complete}])
+      # Send as registration request
+      subject.register_capability(message_router, method_name, method_options)
+      # Mock a valid response
+      response = { 'jsonrpc'=>'2.0', 'id'=> 0, 'result' => nil }
+      original_request = { 'jsonrpc'=>'2.0', 'id' => 0, 'method' => req_method_name, 'params' => req_method_params }
+      subject.parse_register_capability_response!(message_router, response, original_request)
+      # Should show registered
+      expect(subject.capability_registrations(method_name)).to eq([{:registered => true, :state => :complete, :id => request_id}])
+      # Send another registration request
+      subject.register_capability(message_router, method_name, method_options)
+      # Should show as in progress
+      expect(subject.capability_registrations(method_name)).to eq([
+        {:registered => true,  :state => :complete, :id => request_id},
+        {:registered => false, :state => :pending,  :id => request_id2}
+      ])
+      # Mock an error response
+      response = { 'jsonrpc'=>'2.0', 'id'=> 0, 'error' => { 'code' => -1, 'message' => 'mock message' } }
+      original_request = { 'jsonrpc'=>'2.0', 'id' => 0, 'method' => req_method_name, 'params' => req_method_params }
+      subject.parse_register_capability_response!(message_router, response, original_request)
+      # Should still show registered
+      expect(subject.capability_registrations(method_name)).to eq([
+        {:registered => true,  :state => :complete, :id => request_id},
+        {:registered => false, :state => :complete,  :id => request_id2}
+      ])
+    end
+  end
+
   describe '#register_capability' do
     let(:method_name) { 'mockMethod' }
     let(:method_options) { {} }
@@ -197,6 +301,33 @@ describe 'PuppetLanguageServer::LanguageClient' do
     it 'should include the parameters to register' do
       subject.register_capability(message_router, method_name, method_options)
       expect(json_rpc_handler.connection.buffer).to include('"registerOptions":{}')
+    end
+
+    it 'should log a message if a registration is already in progress' do
+      allow(json_rpc_handler).to receive(:send_client_request)
+      expect(PuppetLanguageServer).to receive(:log_message).with(:warn, /#{method_name}/)
+
+      subject.register_capability(message_router, method_name, method_options)
+      subject.register_capability(message_router, method_name, method_options)
+    end
+
+    it 'should not log a message if a previous registration completed' do
+      method_name = nil
+      method_params = nil
+      # Remember the registration so we can fake a response later
+      allow(json_rpc_handler).to receive(:send_client_request) do |n, p|
+        method_name = n
+        method_params = p
+      end
+      expect(PuppetLanguageServer).to_not receive(:log_message).with(:warn, /#{method_name}/)
+      # Send as registration request
+      subject.register_capability(message_router, method_name, method_options)
+      # Mock a valid response
+      response = { 'jsonrpc'=>'2.0', 'id'=> 0, 'result' => nil }
+      original_request = { 'jsonrpc'=>'2.0', 'id' => 0, 'method' => method_name, 'params' => method_params }
+      subject.parse_register_capability_response!(message_router, response, original_request)
+
+      subject.register_capability(message_router, method_name, method_options)
     end
   end
 
@@ -237,11 +368,25 @@ describe 'PuppetLanguageServer::LanguageClient' do
         params
       end
 
-      it 'should log the registration' do
-        allow(PuppetLanguageServer).to receive(:log_message)
-        expect(PuppetLanguageServer).to receive(:log_message).with(:info, /validMethod/)
+      context 'that failed' do
+        before(:each) do
+          response.delete('result') if response.key?('result')
+          response['error'] = { 'code' => -1, 'message' => 'mock message' }
+        end
 
-        subject.parse_register_capability_response!(message_router, response, original_request)
+        it 'should not log the registration' do
+          expect(PuppetLanguageServer).to_not receive(:log_message).with(:info, /validMethod/)
+
+          subject.parse_register_capability_response!(message_router, response, original_request)
+        end
+      end
+
+      context 'that succeeded' do
+        it 'should log the registration' do
+          expect(PuppetLanguageServer).to receive(:log_message).with(:info, /validMethod/)
+
+          subject.parse_register_capability_response!(message_router, response, original_request)
+        end
       end
     end
   end

--- a/spec/languageserver/unit/puppet-languageserver/manifest/format_on_type_provider_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/manifest/format_on_type_provider_spec.rb
@@ -1,0 +1,123 @@
+require 'spec_helper'
+
+describe 'PuppetLanguageServer::Manifest::FormatOnTypeProvider' do
+  let(:subject) { PuppetLanguageServer::Manifest::FormatOnTypeProvider.new }
+
+  describe '::instance' do
+    it 'should exist' do
+      expect(PuppetLanguageServer::Manifest::FormatOnTypeProvider).to respond_to(:instance)
+    end
+
+    it 'should return the same object' do
+      object1 = PuppetLanguageServer::Manifest::FormatOnTypeProvider.instance
+      object2 = PuppetLanguageServer::Manifest::FormatOnTypeProvider.instance
+      expect(object1).to eq(object2)
+    end
+  end
+
+  describe '#format' do
+    let(:formatting_options) do
+      LSP::FormattingOptions.new.tap do |item|
+        item.tabSize = 2
+        item.insertSpaces = true
+      end.to_h
+    end
+
+    [' ', '=', ','].each do |trigger|
+      context "given a trigger character of '#{trigger}'" do
+        it 'should return an empty array' do
+          result = subject.format("{\n  oneline    =>\n}\n", 1, 1, trigger, formatting_options)
+          expect(result).to eq([])
+        end
+      end
+    end
+
+    context "given a trigger character of greater-than '>'" do
+      let(:trigger_character) { '>' }
+      let(:content) do <<-MANIFEST
+user {
+  ensure=> 'something',
+  password   =>
+  name => {
+    'abc' => '123',
+    'def'    => '789',
+  },
+  name2    => 'correct',
+}
+MANIFEST
+      end
+      let(:valid_cursor) { { line: 2, char: 15 } }
+      let(:inside_cursor) { { line: 5, char: 15 } }
+
+      it 'should return an empty array if the cursor is not on a hashrocket' do
+        result = subject.format(content, 1, 1, trigger_character, formatting_options)
+        expect(result).to eq([])
+      end
+
+      it 'should return an empty array if the formatting options uses tabs' do
+        result = subject.format(content, valid_cursor[:line], valid_cursor[:char], trigger_character, formatting_options.tap { |i| i['insertSpaces'] = false} )
+        expect(result).to eq([])
+      end
+
+      it 'should return an empty array if the document is large' do
+        large_content = content + ' ' * 4096
+        result = subject.format(large_content, valid_cursor[:line], valid_cursor[:char], trigger_character, formatting_options)
+        expect(result).to eq([])
+      end
+
+      # Valid hashrocket key tests
+      [
+        { name: 'bare name',            text: 'barename' },
+        { name: 'single quoted string', text: '\'name\'' },
+        { name: 'double quoted string', text: '"name"' },
+      ].each do |testcase|
+        context "and given a manifest with #{testcase[:name]}" do
+          let(:content) { "{\n  a =>\n  ##TESTCASE## => 'value'\n}\n"}
+
+          it 'should return an empty' do
+            result = subject.format(content.gsub('##TESTCASE##', testcase[:text]), 1, 6, trigger_character, formatting_options)
+            # The expected TextEdit should edit the `a =>`
+            expect(result.count).to eq(1)
+            expect(result[0].range.start.line).to eq(1)
+            expect(result[0].range.start.character).to eq(3)
+            expect(result[0].range.end.line).to eq(1)
+            expect(result[0].range.end.character).to eq(4)
+          end
+        end
+      end
+
+      it 'should have valid text edits in the outer hash' do
+        result = subject.format(content, valid_cursor[:line], valid_cursor[:char], trigger_character, formatting_options)
+
+        expect(result.count).to eq(3)
+        expect(result[0].to_h).to eq({"range"=>{"start"=>{"character"=>8,  "line"=>1}, "end"=>{"character"=>8,  "line"=>1}}, "newText"=>"   "})
+        expect(result[1].to_h).to eq({"range"=>{"start"=>{"character"=>10, "line"=>2}, "end"=>{"character"=>13, "line"=>2}}, "newText"=>" "})
+        expect(result[2].to_h).to eq({"range"=>{"start"=>{"character"=>6,  "line"=>3}, "end"=>{"character"=>7,  "line"=>3}}, "newText"=>"     "})
+      end
+
+      it 'should have valid text edits in the inner hash' do
+        result = subject.format(content, inside_cursor[:line], inside_cursor[:char], trigger_character, formatting_options)
+
+        expect(result.count).to eq(1)
+        expect(result[0].to_h).to eq({"range"=>{"start"=>{"character"=>9, "line"=>5}, "end"=>{"character"=>13, "line"=>5}}, "newText"=>" "})
+      end
+
+      # Invalid scenarios
+      [
+        { name: 'only one line',                      content: "{\n  oneline    =>\n}\n" },
+        { name: 'there is nothing to indent',         content: "{\n  oneline    =>\n  nextline12 => 'value',\n}\n" },
+        { name: 'no starting Left Brace',             content: "\n  oneline    =>\n  nextline12 => 'value',\n}\n" },
+        { name: 'no ending Right Brace',              content: "{\n  oneline    =>\n  nextline12 => 'value',\n\n" },
+        { name: 'hashrockets on the same line',       content: "{\n  oneline    => ,  nextline12 => 'value',\n\n"},
+        { name: 'invalid text before the hashrocket', content: "{\n  String[]   =>\n  nextline => 'value',\n}\n" },
+      ].each do |testcase|
+        context "and given a manifest with #{testcase[:name]}" do
+          it 'should return an empty' do
+            result = subject.format(testcase[:content], 1, 15, trigger_character, formatting_options)
+            expect(result).to eq([])
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/languageserver/unit/puppet-languageserver/message_router_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/message_router_spec.rb
@@ -858,7 +858,7 @@ describe 'message_router' do
         end
 
         it 'should attempt to register workspace/didChangeConfiguration' do
-          expect(subject.client).to receive(:register_capability).with(Object, 'workspace/didChangeConfiguration')
+          expect(subject.client).to receive(:register_capability).with('workspace/didChangeConfiguration')
 
           subject.receive_notification(notification_method, notification_params)
         end
@@ -1037,7 +1037,7 @@ describe 'message_router' do
         let(:config_settings) { nil }
 
         it 'should send a configuration request' do
-          expect(subject.client).to receive(:send_configuration_request).with(Object)
+          expect(subject.client).to receive(:send_configuration_request).with(no_args)
 
           subject.receive_notification(notification_method, notification_params)
         end
@@ -1116,7 +1116,7 @@ describe 'message_router' do
       let(:request_params) { {} }
 
       it 'should call client.parse_register_capability_response!' do
-        expect(subject.client).to receive(:parse_register_capability_response!).with(Object, response, original_request)
+        expect(subject.client).to receive(:parse_register_capability_response!).with(response, original_request)
 
         subject.receive_response(response, original_request)
       end

--- a/spec/languageserver/unit/puppet-languageserver/message_router_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/message_router_spec.rb
@@ -1123,12 +1123,16 @@ describe 'message_router' do
     end
 
     context 'given an original workspace/configuration request' do
-      let(:response_result) { { 'setting1' => 'value1' } }
+      let(:response_result) { [{ 'setting1' => 'value1' }] }
       let(:request_method) { 'workspace/configuration'}
-      let(:request_params) { {} }
+      let(:request_params) do
+        params = LSP::ConfigurationParams.new.from_h!('items' => [])
+        params.items << LSP::ConfigurationItem.new.from_h!('section' => 'mock')
+        params
+      end
 
       it 'should call client.parse_lsp_configuration_settings!' do
-        expect(subject.client).to receive(:parse_lsp_configuration_settings!).with(response_result)
+        expect(subject.client).to receive(:parse_lsp_configuration_settings!).with({ 'mock' => response_result[0] })
 
         subject.receive_response(response, original_request)
       end


### PR DESCRIPTION
Builds on #185 

Fixes #177 

---

Previously the onTypeFormatting provider was created and responds to client
settings, turning it on and off appropriately.  This commit actually adds the
on type formatter:

* Only for puppet manifests (.pp)
* Uses puppet-lint lexer to tokenise the document and uses the tokens to
  determine indenting
* Will not operate if the document is over 4KB in size or the client is using
  tabs instead of spaces
* Adds tests for the formatting

---

![hashrocket](https://user-images.githubusercontent.com/5819622/63691109-f081a080-c840-11e9-9fad-ae2c655ba6cf.gif)