### PR TITLE
(GH-201) Fix hashrocket alignment in multi-resource declarations

### DIFF
--- a/lib/puppet-languageserver/manifest/format_on_type_provider.rb
+++ b/lib/puppet-languageserver/manifest/format_on_type_provider.rb
@@ -29,10 +29,10 @@ module PuppetLanguageServer
         # The cursor should be at the end of a hashrocket, otherwise exit
         return result unless cursor_token.type == :FARROW
 
-        # Find the start of the hash with respect to the cursor
-        start_brace = cursor_token.prev_token_of(:LBRACE, skip_blocks: true)
-        # Find the end  of the hash with respect to the cursor
-        end_brace = cursor_token.next_token_of(:RBRACE, skip_blocks: true)
+        # Find the start of the hash (or semicolon for multi-resource definitions) with respect to the cursor
+        start_brace = cursor_token.prev_token_of(%i[LBRACE SEMIC], skip_blocks: true)
+        # Find the end of the hash (or semicolon for multi-resource definitions) with respect to the cursor
+        end_brace = cursor_token.next_token_of(%i[RBRACE SEMIC], skip_blocks: true)
 
         # The line count between the start and end brace needs to be at least 2 lines. Otherwise there's nothing to align to
         return result if end_brace.nil? || start_brace.nil? || end_brace.line - start_brace.line <= 2

--- a/spec/languageserver/unit/puppet-languageserver/manifest/format_on_type_provider_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/manifest/format_on_type_provider_spec.rb
@@ -102,6 +102,35 @@ MANIFEST
         expect(result[0].to_h).to eq({"range"=>{"start"=>{"character"=>9, "line"=>5}, "end"=>{"character"=>13, "line"=>5}}, "newText"=>" "})
       end
 
+      context "when declaring multiple resources in the title" do
+        let(:content) do <<-MANIFEST
+file {
+  default:
+    a => 'value',
+    b   => 'value2',
+  ;
+  'title1':
+    a  => 'value1',
+    bcd => 'value2',
+    e    => 'value3',
+  ;
+  'title2':
+    a => directory,
+    b  => '0770',
+  ;
+}
+MANIFEST
+        end
+
+        it 'should return text edits only for the inner resource' do
+          result = subject.format(content, 6, 9, trigger_character, formatting_options)
+          # The expected TextEdits should edit the `a  =>` and `e    =>` in the middle resource only
+          expect(result.count).to eq(2)
+          expect(result[0].to_h).to eq({"range"=>{"start"=>{"character"=>5, "line"=>6}, "end"=>{"character"=>7, "line"=>6}}, "newText"=>"   "})
+          expect(result[1].to_h).to eq({"range"=>{"start"=>{"character"=>5, "line"=>8}, "end"=>{"character"=>9, "line"=>8}}, "newText"=>"   "})
+        end
+      end
+
       # Invalid scenarios
       [
         { name: 'only one line',                      content: "{\n  oneline    =>\n}\n" },


### PR DESCRIPTION
Fixes #201 

Multi-resource declarations [1] are delimited by semi-colons as well as being
inside a hash block.  This commit modifies the hashrocket detection to also
take into account semi-colons and adds a test for this scenario.

[1] https://puppet.com/docs/puppet/latest/style_guide.html#multiple-resources
