### PR TITLE
(maint) Update for Rubocop 0.77.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,7 +78,7 @@ Style/SymbolProc:
 Style/HashSyntax:
   Enabled: false
 
-Layout/AlignHash:
+Layout/HashAlignment:
   EnforcedHashRocketStyle: table
 
 Naming/RescuedExceptionsVariableName:
@@ -90,4 +90,8 @@ Style/NumericPredicate:
 
 # This is not valid on Ruby 2.1
 Style/SafeNavigation:
+  Enabled: false
+
+# This is not valid on Ruby 2.1
+Layout/HeredocIndentation:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -12,10 +12,8 @@ group :development do
   gem 'rake', '>= 10.4',            :require => false
   gem 'rspec', '>= 3.2',            :require => false
 
-  if RUBY_VERSION =~ /^2\.1\./
-    gem "rubocop", "<= 0.57.2", :require => false, :platforms => [:ruby, :x64_mingw]
-  else
-    gem "rubocop", ">= 0.60.0", :require => false, :platforms => [:ruby, :x64_mingw]
+  if Gem::Version.create(RUBY_VERSION) >= Gem::Version.create('2.3.0')
+    gem "rubocop", ">= 0.77.0", :require => false, :platforms => [:ruby, :x64_mingw]
   end
 
   if ENV['PUPPET_GEM_VERSION']

--- a/lib/puppet-debugserver/debug_session/hook_handlers.rb
+++ b/lib/puppet-debugserver/debug_session/hook_handlers.rb
@@ -144,22 +144,20 @@ module PuppetDebugServer
           # Stepping-in is basically break on everything
           # Re-raise the hook as a step breakpoint
           @debug_session.execute_hook(:hook_step_breakpoint, [ast_classname, ''] + args)
-          return
         when :next
           # Next will break on anything at this Pop depth or shallower than this Pop depth. Re-raise the hook as a step breakpoint
           depth = @debug_session.flow_control.run_mode.options[:pops_depth_level] || -1
-          if @debug_session.puppet_session_state.actual.pops_depth_level <= depth
+          if @debug_session.puppet_session_state.actual.pops_depth_level <= depth # rubocop:disable Style/IfUnlessModifier
             @debug_session.execute_hook(:hook_step_breakpoint, [ast_classname, ''] + args)
-            return
           end
         when :stepout
           # Stepping-Out will break on anything shallower than this Pop depth. Re-raise the hook as a step breakpoint
           depth = @debug_session.flow_control.run_mode.options[:pops_depth_level] || -1
-          if @debug_session.puppet_session_state.actual.pops_depth_level < depth
+          if @debug_session.puppet_session_state.actual.pops_depth_level < depth # rubocop:disable Style/IfUnlessModifier
             @debug_session.execute_hook(:hook_step_breakpoint, [ast_classname, ''] + args)
-            return
           end
         end
+        nil
       end
 
       # Fires when a source/line breakpoint is hit

--- a/lib/puppet-languageserver-sidecar/puppet_modulepath_monkey_patches.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_modulepath_monkey_patches.rb
@@ -73,9 +73,9 @@ class Puppet::Node::Environment # rubocop:disable Style/ClassAndModuleChildren
       # https://github.com/puppetlabs/puppet/commit/935c0311dbaf1df03937822525c36b26de5390ef
       # We need to switch the creation based on whether the modules_strict_semver? method is available
       return Puppet::Module.new(module_name, path, self, modules_strict_semver?) if respond_to?('modules_strict_semver?')
-      return Puppet::Module.new(module_name, path, self)
+      Puppet::Module.new(module_name, path, self)
     rescue StandardError
-      return nil
+      nil
     end
   end
 

--- a/lib/puppet-languageserver/crash_dump.rb
+++ b/lib/puppet-languageserver/crash_dump.rb
@@ -43,7 +43,7 @@ TEXT
 
       crash_file = filename.nil? ? default_crash_file : filename
       File.open(crash_file, 'wb') { |file| file.write(crashtext) }
-    rescue # rubocop:disable Style/RescueStandardError, Lint/HandleExceptions
+    rescue # rubocop:disable Style/RescueStandardError, Lint/SuppressedException
       # Swallow all errors.  Errors in the error handler should not
       # terminate the application
     end

--- a/lib/puppet-languageserver/manifest/validation_provider.rb
+++ b/lib/puppet-languageserver/manifest/validation_provider.rb
@@ -80,11 +80,11 @@ module PuppetLanguageServer
                                             'message'  => problem[:message])
             end
           end
-        # rubocop:disable Lint/HandleExceptions
+        # rubocop:disable Lint/SuppressedException
         rescue StandardError
           # If anything catastrophic happens we resort to puppet parsing anyway
         end
-        # rubocop:enable Lint/HandleExceptions
+        # rubocop:enable Lint/SuppressedException
 
         # TODO: Should I wrap this thing in a big rescue block?
         Puppet[:code] = content

--- a/lib/puppet-languageserver/message_handler.rb
+++ b/lib/puppet-languageserver/message_handler.rb
@@ -64,11 +64,11 @@ module PuppetLanguageServer
 
       begin
         node_graph = PuppetLanguageServer::PuppetHelper.get_node_graph(content, documents.store_root_path)
-        return LSP::CompileNodeGraphResponse.new('dotContent' => node_graph.dot_content,
-                                                 'error'      => node_graph.error_content)
+        LSP::CompileNodeGraphResponse.new('dotContent' => node_graph.dot_content,
+                                          'error'      => node_graph.error_content)
       rescue StandardError => e
         PuppetLanguageServer.log_message(:error, "(puppet/compileNodeGraph) Error generating node graph. #{e}")
-        return LSP::CompileNodeGraphResponse.new('error' => 'An internal error occured while generating the the node graph. Please see the debug log files for more information.')
+        LSP::CompileNodeGraphResponse.new('error' => 'An internal error occured while generating the the node graph. Please see the debug log files for more information.')
       end
     end
 
@@ -92,7 +92,7 @@ module PuppetLanguageServer
     rescue StandardError => e
       PuppetLanguageServer.log_message(:error, "(puppet/fixDiagnosticErrors) #{e}")
       unless formatted_request.nil?
-        return LSP::PuppetFixDiagnosticErrorsResponse.new(
+        LSP::PuppetFixDiagnosticErrorsResponse.new(
           'documentUri'  => formatted_request.documentUri,
           'fixesApplied' => 0,
           'newContent'   => formatted_request.alwaysReturnContent ? content : nil # rubocop:disable Metrics/BlockNesting
@@ -109,7 +109,7 @@ module PuppetLanguageServer
 
       case documents.document_type(file_uri)
       when :manifest
-        return PuppetLanguageServer::Manifest::CompletionProvider.complete(content, line_num, char_num, :context => context, :tasks_mode => PuppetLanguageServer::DocumentStore.plan_file?(file_uri))
+        PuppetLanguageServer::Manifest::CompletionProvider.complete(content, line_num, char_num, :context => context, :tasks_mode => PuppetLanguageServer::DocumentStore.plan_file?(file_uri))
       else
         raise "Unable to provide completion on #{file_uri}"
       end
@@ -133,7 +133,7 @@ module PuppetLanguageServer
       content = documents.document(file_uri)
       case documents.document_type(file_uri)
       when :manifest
-        return PuppetLanguageServer::Manifest::HoverProvider.resolve(content, line_num, char_num, :tasks_mode => PuppetLanguageServer::DocumentStore.plan_file?(file_uri))
+        PuppetLanguageServer::Manifest::HoverProvider.resolve(content, line_num, char_num, :tasks_mode => PuppetLanguageServer::DocumentStore.plan_file?(file_uri))
       else
         raise "Unable to provide hover on #{file_uri}"
       end
@@ -150,7 +150,7 @@ module PuppetLanguageServer
 
       case documents.document_type(file_uri)
       when :manifest
-        return PuppetLanguageServer::Manifest::DefinitionProvider.find_definition(content, line_num, char_num, :tasks_mode => PuppetLanguageServer::DocumentStore.plan_file?(file_uri))
+        PuppetLanguageServer::Manifest::DefinitionProvider.find_definition(content, line_num, char_num, :tasks_mode => PuppetLanguageServer::DocumentStore.plan_file?(file_uri))
       else
         raise "Unable to provide definition on #{file_uri}"
       end
@@ -165,7 +165,7 @@ module PuppetLanguageServer
 
       case documents.document_type(file_uri)
       when :manifest
-        return PuppetLanguageServer::Manifest::DocumentSymbolProvider.extract_document_symbols(content, :tasks_mode => PuppetLanguageServer::DocumentStore.plan_file?(file_uri))
+        PuppetLanguageServer::Manifest::DocumentSymbolProvider.extract_document_symbols(content, :tasks_mode => PuppetLanguageServer::DocumentStore.plan_file?(file_uri))
       else
         raise "Unable to provide definition on #{file_uri}"
       end
@@ -183,7 +183,7 @@ module PuppetLanguageServer
 
       case documents.document_type(file_uri)
       when :manifest
-        return PuppetLanguageServer::Manifest::FormatOnTypeProvider.instance.format(
+        PuppetLanguageServer::Manifest::FormatOnTypeProvider.instance.format(
           content,
           line_num,
           char_num,
@@ -206,7 +206,7 @@ module PuppetLanguageServer
 
       case documents.document_type(file_uri)
       when :manifest
-        return PuppetLanguageServer::Manifest::SignatureProvider.signature_help(
+        PuppetLanguageServer::Manifest::SignatureProvider.signature_help(
           content,
           line_num,
           char_num,

--- a/lib/puppet_editor_services/server/stdio.rb
+++ b/lib/puppet_editor_services/server/stdio.rb
@@ -70,7 +70,7 @@ module PuppetEditorServices
           rescue EOFError
             log('Reading from pipe has reached End of File.  Exiting STDIO server')
             stop
-          rescue # rubocop:disable Style/RescueStandardError, Lint/HandleExceptions
+          rescue # rubocop:disable Style/RescueStandardError, Lint/SuppressedException
             # Any errors here should be swallowed because the pipe could be in any state
           end
           # since readpartial may return a nil at EOF, skip returning that value

--- a/lib/puppet_editor_services/server/tcp.rb
+++ b/lib/puppet_editor_services/server/tcp.rb
@@ -200,7 +200,7 @@ module PuppetEditorServices
               if self.class.services[io]
                 begin
                   callback(self, :add_connection, io.accept_nonblock, self.class.services[io])
-                rescue Errno::EWOULDBLOCK # rubocop:disable Lint/HandleExceptions
+                rescue Errno::EWOULDBLOCK # rubocop:disable Lint/SuppressedException
                   # There's nothing to handle. Swallow the error
                 rescue StandardError => e
                   log(e.message)


### PR DESCRIPTION
This commit updates the project for Rubocop 0.77.0

Due to there being so many differences in rubocop for Ruby < 2.3.0, this commit
also stops bundling rubocop for old Ruby versions.
