### PR TITLE
(GH-213) Use Facts from the Sidecar

### DIFF
--- a/lib/puppet-languageserver/facter_helper.rb
+++ b/lib/puppet-languageserver/facter_helper.rb
@@ -2,62 +2,49 @@
 
 module PuppetLanguageServer
   module FacterHelper
-    @ops_lock = Mutex.new
     @facts_loaded = nil
 
-    def self.reset
-      @ops_lock.synchronize do
-        _reset
-      end
+    def self.cache
+      PuppetLanguageServer::PuppetHelper.cache
     end
 
-    def self.load_facts_async
-      Thread.new do
-        load_facts
-      end
+    def self.sidecar_queue
+      PuppetLanguageServer::PuppetHelper.sidecar_queue
     end
 
+    # Facts
     def self.facts_loaded?
       @facts_loaded.nil? ? false : @facts_loaded
     end
 
-    def self.load_facts
-      @ops_lock.synchronize do
-        _load_facts
-      end
-    end
-
-    def self.facts
-      return {} if @facts_loaded == false
-      @ops_lock.synchronize do
-        _load_facts if @fact_hash.nil?
-        @fact_hash.clone
-      end
-    end
-
-    # DO NOT ops_lock on any of these methods
-    # deadlocks will ensue!
-    def self._reset
-      @facts_loaded = nil
-      Facter.reset
-      @fact_hash = nil
-    end
-    private_class_method :_reset
-
-    def self._load_facts
-      _reset
-      @fact_hash = {}
-      begin
-        Facter.loadfacts
-        @fact_hash = Facter.to_hash
-      rescue StandardError => e
-        PuppetLanguageServer.log_message(:error, "[FacterHelper::_load_facts] Error loading facts #{e.message} #{e.backtrace}")
-      rescue LoadError => e
-        PuppetLanguageServer.log_message(:error, "[FacterHelper::_load_facts] Error loading facts (LoadError) #{e.message} #{e.backtrace}")
-      end
-      PuppetLanguageServer.log_message(:debug, "[FacterHelper::_load_facts] Finished loading #{@fact_hash.keys.count} facts")
+    def self.assert_facts_loaded
       @facts_loaded = true
     end
-    private_class_method :_load_facts
+
+    def self.load_facts
+      @facts_loaded = false
+      sidecar_queue.execute_sync('facts', [])
+    end
+
+    def self.load_facts_async
+      @facts_loaded = false
+      sidecar_queue.enqueue('facts', [])
+    end
+
+    def self.fact(name)
+      return nil if @facts_loaded == false
+      cache.object_by_name(:fact, name)
+    end
+
+    def self.fact_value(name)
+      return nil if @facts_loaded == false
+      object = cache.object_by_name(:fact, name)
+      object.nil? ? nil : object.value
+    end
+
+    def self.fact_names
+      return [] if @facts_loaded == false
+      cache.object_names_by_section(:fact).map(&:to_s)
+    end
   end
 end

--- a/lib/puppet-languageserver/manifest/completion_provider.rb
+++ b/lib/puppet-languageserver/manifest/completion_provider.rb
@@ -144,7 +144,7 @@ module PuppetLanguageServer
       end
 
       def self.all_facts(&block)
-        PuppetLanguageServer::FacterHelper.facts.each_key do |name|
+        PuppetLanguageServer::FacterHelper.fact_names.each do |name|
           item = LSP::CompletionItem.new(
             'label'      => name.to_s,
             'insertText' => "'#{name}'",
@@ -206,7 +206,7 @@ module PuppetLanguageServer
         data = result.data
         case data['type']
         when 'variable_expr_fact'
-          value = PuppetLanguageServer::FacterHelper.facts[data['expr']]
+          value = PuppetLanguageServer::FacterHelper.fact_value(data['expr'])
           # TODO: More things?
           result.documentation = value.to_s
 

--- a/lib/puppet-languageserver/manifest/hover_provider.rb
+++ b/lib/puppet-languageserver/manifest/hover_provider.rb
@@ -107,8 +107,9 @@ module PuppetLanguageServer
 
       # Content generation functions
       def self.get_fact_content(factname)
-        return nil unless PuppetLanguageServer::FacterHelper.facts.key?(factname)
-        value = PuppetLanguageServer::FacterHelper.facts[factname]
+        fact = PuppetLanguageServer::FacterHelper.fact(factname)
+        return nil if fact.nil?
+        value = fact.value
         content = "**#{factname}** Fact\n\n"
 
         if value.is_a?(Hash)

--- a/lib/puppet-languageserver/puppet_helper.rb
+++ b/lib/puppet-languageserver/puppet_helper.rb
@@ -305,7 +305,6 @@ module PuppetLanguageServer
     def self.sidecar_queue
       @sidecar_queue_obj ||= PuppetLanguageServer::SidecarQueue.new(@helper_options)
     end
-    private_class_method :sidecar_queue
 
     def self.with_temporary_file(content)
       tempfile = Tempfile.new('langserver-sidecar')

--- a/lib/puppet-languageserver/puppet_helper/cache.rb
+++ b/lib/puppet-languageserver/puppet_helper/cache.rb
@@ -3,7 +3,7 @@
 module PuppetLanguageServer
   module PuppetHelper
     class Cache
-      SECTIONS = %i[class type function datatype].freeze
+      SECTIONS = %i[class type function datatype fact].freeze
       ORIGINS = %i[default workspace bolt].freeze
 
       def initialize(_options = {})

--- a/lib/puppet-languageserver/sidecar_protocol.rb
+++ b/lib/puppet-languageserver/sidecar_protocol.rb
@@ -521,24 +521,26 @@ module PuppetLanguageServer
         end
       end
 
-      class Facts < Hash
-        include Base
+      class Fact < BasePuppetObject
+        attr_accessor :value
+
+        def to_h
+          super.to_h.merge(
+            'value' => value
+          )
+        end
 
         def from_h!(value)
-          value.keys.each { |key| self[key] = value[key] }
+          super
+
+          self.value = value['value']
           self
         end
+      end
 
-        def to_json(*options)
-          ::JSON.generate(to_h, options)
-        end
-
-        def from_json!(json_string)
-          obj = ::JSON.parse(json_string)
-          obj.each do |key, value|
-            self[key] = value
-          end
-          self
+      class FactList < BasePuppetObjectList
+        def child_type
+          Fact
         end
       end
     end

--- a/lib/puppet-languageserver/sidecar_queue.rb
+++ b/lib/puppet-languageserver/sidecar_queue.rb
@@ -111,6 +111,13 @@ module PuppetLanguageServer
 
         PuppetLanguageServer::PuppetHelper.assert_default_types_loaded
 
+      when 'facts'
+        list = PuppetLanguageServer::Sidecar::Protocol::FactList.new.from_json!(result)
+        @cache.import_sidecar_list!(list, :fact, :default)
+        PuppetLanguageServer.log_message(:debug, "SidecarQueue Thread: facts returned #{list.count} items")
+
+        PuppetLanguageServer::FacterHelper.assert_facts_loaded
+
       when 'node_graph'
         return PuppetLanguageServer::Sidecar::Protocol::NodeGraph.new.from_json!(result)
 

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/facter_helper_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/facter_helper_spec.rb
@@ -20,24 +20,33 @@ describe 'PuppetLanguageServerSidecar::FacterHelper' do
     return stdout.bytes.pack('U*')
   end
 
-  let(:default_fact_names) { ['hostname', 'fixture_agent_custom_fact'] }
-  let(:module_fact_names) { ['fixture_module_custom_fact', 'fixture_module_external_fact'] }
-  let(:environment_fact_names) { ['fixture_environment_custom_fact', 'fixture_environment_external_fact'] }
+  RSpec::Matchers.define :contain_child_with_key do |key|
+    match do |actual|
+      !(actual.index { |item| item.key == key }).nil?
+    end
+
+    failure_message do |actual|
+      "expected that #{actual.class.to_s} would contain a child with key #{key}"
+    end
+  end
+
+  let(:default_fact_names) { %i[hostname fixture_agent_custom_fact] }
+  let(:module_fact_names) { %i[fixture_module_custom_fact fixture_module_external_fact] }
+  let(:environment_fact_names) { %i[fixture_environment_custom_fact fixture_environment_external_fact] }
 
   describe 'when running facts action' do
     let (:cmd_options) { ['--action', 'facts'] }
 
     it 'should return a deserializable facts object with all default facts' do
       result = run_sidecar(cmd_options)
-      deserial = PuppetLanguageServer::Sidecar::Protocol::Facts.new
+      deserial = PuppetLanguageServer::Sidecar::Protocol::FactList.new
       expect { deserial.from_json!(result) }.to_not raise_error
-
       default_fact_names.each do |name|
-        expect(deserial).to include(name)
+        expect(deserial).to contain_child_with_key(name)
       end
 
       module_fact_names.each do |name|
-        expect(deserial).not_to include(name)
+        expect(deserial).to_not contain_child_with_key(name)
       end
     end
   end
@@ -51,15 +60,15 @@ describe 'PuppetLanguageServerSidecar::FacterHelper' do
 
       it 'should return a deserializable facts object with default facts and workspace facts' do
         result = run_sidecar(cmd_options)
-        deserial = PuppetLanguageServer::Sidecar::Protocol::Facts.new
+        deserial = PuppetLanguageServer::Sidecar::Protocol::FactList.new
         expect { deserial.from_json!(result) }.to_not raise_error
 
         default_fact_names.each do |name|
-          expect(deserial).to include(name)
+          expect(deserial).to contain_child_with_key(name)
         end
 
         module_fact_names.each do |name|
-          expect(deserial).to include(name)
+          expect(deserial).to contain_child_with_key(name)
         end
       end
     end
@@ -74,15 +83,15 @@ describe 'PuppetLanguageServerSidecar::FacterHelper' do
 
       it 'should return a deserializable facts object with default facts and workspace facts' do
         result = run_sidecar(cmd_options)
-        deserial = PuppetLanguageServer::Sidecar::Protocol::Facts.new
+        deserial = PuppetLanguageServer::Sidecar::Protocol::FactList.new
         expect { deserial.from_json!(result) }.to_not raise_error
 
         default_fact_names.each do |name|
-          expect(deserial).to include(name)
+          expect(deserial).to contain_child_with_key(name)
         end
 
         environment_fact_names.each do |name|
-          expect(deserial).to include(name)
+          expect(deserial).to contain_child_with_key(name)
         end
       end
     end

--- a/spec/languageserver/spec_helper.rb
+++ b/spec/languageserver/spec_helper.rb
@@ -24,12 +24,14 @@ def wait_for_puppet_loading
     break if PuppetLanguageServer::PuppetHelper.default_functions_loaded? &&
              PuppetLanguageServer::PuppetHelper.default_types_loaded? &&
              PuppetLanguageServer::PuppetHelper.default_classes_loaded? &&
-             PuppetLanguageServer::PuppetHelper.default_datatypes_loaded?
+             PuppetLanguageServer::PuppetHelper.default_datatypes_loaded? &&
+             PuppetLanguageServer::FacterHelper.facts_loaded?
     sleep(1)
     interation += 1
     next if interation < 90
     raise <<-ERRORMSG
             Puppet has not be initialised in time:
+            facts_loaded? = #{PuppetLanguageServer::FacterHelper.facts_loaded?}
             functions_loaded? = #{PuppetLanguageServer::PuppetHelper.default_functions_loaded?}
             types_loaded? = #{PuppetLanguageServer::PuppetHelper.default_types_loaded?}
             classes_loaded? = #{PuppetLanguageServer::PuppetHelper.default_classes_loaded?}

--- a/spec/languageserver/spec_helper.rb
+++ b/spec/languageserver/spec_helper.rb
@@ -59,6 +59,13 @@ def add_random_basepuppetobject_values!(value)
   value
 end
 
+def random_sidecar_fact(key = nil)
+  result = add_random_basepuppetobject_values!(PuppetLanguageServer::Sidecar::Protocol::Fact.new())
+  result.key = key unless key.nil?
+  result.value = 'value' + rand(1000).to_s
+  result
+end
+
 def random_sidecar_puppet_class(key = nil)
   result = add_random_basepuppetobject_values!(PuppetLanguageServer::Sidecar::Protocol::PuppetClass.new())
   result.key = key unless key.nil?

--- a/spec/languageserver/unit/puppet-languageserver/sidecar_protocol_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/sidecar_protocol_spec.rb
@@ -70,6 +70,7 @@ describe 'PuppetLanguageServer::Sidecar::Protocol' do
   end
 
   basepuppetobject_properties = [:key, :calling_source, :source, :line, :char, :length]
+  fact_properties = [:value]
   nodegraph_properties = [:dot_content, :error_content]
   puppetclass_properties = [:doc, :parameters]
   puppetdatatype_properties = [:doc, :alias_of, :attributes, :is_type_alias]
@@ -131,27 +132,50 @@ describe 'PuppetLanguageServer::Sidecar::Protocol' do
     end
   end
 
-  describe 'Facts' do
-    let(:subject_klass) { PuppetLanguageServer::Sidecar::Protocol::Facts }
+  describe 'Fact' do
+    let(:subject_klass) { PuppetLanguageServer::Sidecar::Protocol::Fact }
     let(:subject) {
       value = subject_klass.new
-      value['val1_' + rand(1000).to_s] = rand(1000).to_s
-      value['val2_' + rand(1000).to_s] = rand(1000).to_s
-      value['val3_' + rand(1000).to_s] = rand(1000).to_s
+      value.value = 'value'
+      add_default_basepuppetobject_values!(value)
+    }
+
+    it_should_behave_like 'a base Sidecar Protocol Puppet object'
+
+    fact_properties.each do |testcase|
+      it "instance should respond to #{testcase}" do
+        expect(subject).to respond_to(testcase)
+      end
+    end
+
+    describe '#from_json!' do
+      (basepuppetobject_properties + fact_properties).each do |testcase|
+        it "should deserialize a serialized #{testcase} value" do
+          serial = subject.to_json
+          deserial = subject_klass.new.from_json!(serial)
+
+          expect(deserial.send(testcase)).to eq(subject.send(testcase))
+        end
+      end
+    end
+  end
+
+  describe 'FactList' do
+    let(:subject_klass) { PuppetLanguageServer::Sidecar::Protocol::FactList }
+    let(:subject) {
+      value = subject_klass.new
+      value << random_sidecar_fact
+      value << random_sidecar_fact
+      value << random_sidecar_fact
       value
     }
 
-    it_should_behave_like 'a base Sidecar Protocol object'
+    it_should_behave_like 'a base Sidecar Protocol Puppet object list'
 
-    describe '#from_json!' do
-      it "should deserialize a serialized value" do
-        serial = subject.to_json
-        deserial = subject_klass.new.from_json!(serial)
+    it_should_behave_like 'a serializable object list'
 
-        subject.keys.each do |key|
-          expect(deserial[key]).to eq(subject[key])
-        end
-      end
+    it "instance should have a childtype of Fact" do
+      expect(subject.child_type).to eq(PuppetLanguageServer::Sidecar::Protocol::Fact)
     end
   end
 


### PR DESCRIPTION
Fixes #213 

#213 Part 2

---

Previously in commit 590804e the Sidecar was updated to retrieve facts
however the object module was incorrectly setup to be used by the Language
Server in-memory cache. This commit changes the protocol to have a Fact and
FactList, similar to PuppetClass etc.

---

Now that facts can be loaded from the Sidecar, the FacterHelper needs to be
updated to use these instead of calling Facter directly.  This commit:

* Modifies the FacterHelper to call the sidecar queue to get the Fact
  information
* Modifies the FacterHelper to expose methods to query facts
* Updates the cache to store facts
* Updates the tests for the new Fact collection method