### PR TITLE
(GH-221) Puppet Node Graph to json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Unreleased
 
+## 0.24.0 - 2020-01-28
+
+### Fixed
+
+- ([GH-199](https://github.com/lingua-pupuli/puppet-editor-services/issues/199)) Fixes for Puppet 5.5.18
+
+### Changed
+
+- ([GH-213](https://github.com/lingua-pupuli/puppet-editor-services/issues/213)) Gather Facts from the Sidecar instead of the Server process
+
 ## 0.23.0 - 2019-12-04
 
 ### Added

--- a/lib/puppet-languageserver-sidecar/puppet_parser_helper.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_parser_helper.rb
@@ -28,6 +28,25 @@ module PuppetLanguageServerSidecar
       result
     end
 
+    def self.compile_node_graph_to_json(content)
+      result = PuppetLanguageServerSidecar::Protocol::NodeGraph.new
+
+      begin
+        node_graph = compile_to_pretty_relationship_graph(content)
+        if node_graph.vertices.count.zero?
+          result.set_error('There were no resources created in the node graph. Is there an include statement missing?')
+        else
+          result.content = JSON.generate(node_graph.to_data_hash)
+        end
+      rescue StandardError => e
+        result.set_error("Error while parsing the file. #{e}")
+      rescue LoadError => e
+        result.set_error("Load error while parsing the file. #{e}")
+      end
+
+      result
+    end
+
     # Reference - https://github.com/puppetlabs/puppet/blob/master/spec/lib/puppet_spec/compiler.rb
     def self.compile_to_catalog(string, node = Puppet::Node.new('test'))
       Puppet[:code] = string

--- a/lib/puppet_editor_services/version.rb
+++ b/lib/puppet_editor_services/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module PuppetEditorServices
-  PUPPETEDITORSERVICESVERSION = '0.23.0' unless defined? PUPPETEDITORSERVICESVERSION
+  PUPPETEDITORSERVICESVERSION = '0.24.0' unless defined? PUPPETEDITORSERVICESVERSION
 
   # @api public
   #

--- a/lib/puppet_languageserver_sidecar.rb
+++ b/lib/puppet_languageserver_sidecar.rb
@@ -314,7 +314,7 @@ module PuppetLanguageServerSidecar
       end
       begin
         manifest = File.open(options[:action_parameters]['source'], 'r:UTF-8') { |f| f.read }
-        PuppetLanguageServerSidecar::PuppetParserHelper.compile_node_graph(manifest)
+        PuppetLanguageServerSidecar::PuppetParserHelper.compile_node_graph_to_json(manifest)
       rescue StandardError => e
         log_message(:error, "Unable to compile the manifest. #{e}")
         result.set_error("Unable to compile the manifest. #{e}")

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/puppet_parser_helper_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/puppet_parser_helper_spec.rb
@@ -59,4 +59,53 @@ describe 'PuppetLanguageServerSidecar::PuppetParserHelper' do
       end
     end
   end
+
+  describe '#compile_node_graph_to_json' do
+    def tasks_supported?
+      Gem::Version.new(Puppet.version) >= Gem::Version.new('5.4.0')
+    end
+
+    before(:each) do
+      @original_taskmode = Puppet[:tasks] if tasks_supported?
+      Puppet[:tasks] = false if tasks_supported?
+    end
+
+    after(:each) do
+      Puppet[:tasks] = @original_taskmode if tasks_supported?
+    end
+
+    context 'a valid manifest' do
+      let(:manifest) { "user { 'test':\nensure => present\n}\n "}
+
+      it 'should compile succesfully' do
+        result = subject.compile_node_graph_to_json(manifest)
+        expect(result).to_not be_nil
+
+        # Expect no errors
+        expect(result.error_content.to_s).to eq('')
+      end
+    end
+
+    context 'a valid manifest with no resources' do
+      let(:manifest) { "" }
+
+      it 'should compile with an error' do
+        result = subject.compile_node_graph_to_json(manifest)
+        expect(result).to_not be_nil
+        expect(result.dot_content).to eq("")
+        expect(result.error_content).to match(/no resources created in the node graph/)
+      end
+    end
+
+    context 'an invalid manifest' do
+      let(:manifest) { "I am an invalid manifest" }
+
+      it 'should compile with an error' do
+        result = subject.compile_node_graph_to_json(manifest)
+        expect(result).to_not be_nil
+        expect(result.dot_content).to eq("")
+        expect(result.error_content).to match(/Error while parsing the file./)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This commit changes the Node Graph method to return a json data hash
instead of a dot graph to support https://github.com/lingua-pupuli/puppet-vscode/issues/613

Fixes #221 