### PR TITLE
(GH-221) Add generic Graph response

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -95,3 +95,13 @@ Style/SafeNavigation:
 # This is not valid on Ruby 2.1
 Layout/HeredocIndentation:
   Enabled: false
+
+# Rubocop 0.80.0 rules
+Style/HashEachMethods:
+  Enabled: false
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development do
   gem 'rspec', '>= 3.2',            :require => false
 
   if Gem::Version.create(RUBY_VERSION) >= Gem::Version.create('2.3.0')
-    gem "rubocop", ">= 0.77.0", :require => false, :platforms => [:ruby, :x64_mingw]
+    gem "rubocop", ">= 0.80.0", :require => false, :platforms => [:ruby, :x64_mingw]
   end
 
   if ENV['PUPPET_GEM_VERSION']

--- a/lib/lsp/lsp_custom.rb
+++ b/lib/lsp/lsp_custom.rb
@@ -55,12 +55,14 @@ module LSP
     end
   end
 
-  # export interface CompileNodeGraphResponse {
-  #   dotContent: string;
+  # export interface GraphResponse {
+  #   vertices: array;
+  #   edges: array;
   #   data: string;
   # }
-  class CompileNodeGraphResponse < LSPBase
-    attr_accessor :dotContent # type: string
+  class GraphResponse < LSPBase
+    attr_accessor :vertices # type: object[]
+    attr_accessor :edges # type: object[]
     attr_accessor :error # type: string
 
     def initialize(initial_hash = nil)
@@ -70,7 +72,8 @@ module LSP
 
     def from_h!(value)
       value = {} if value.nil?
-      self.dotContent = value['dotContent']
+      self.vertices = value['vertices']
+      self.edges = value['edges']
       self.error = value['error']
       self
     end

--- a/lib/puppet-languageserver-sidecar/puppet_parser_helper.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_parser_helper.rb
@@ -3,21 +3,26 @@
 module PuppetLanguageServerSidecar
   module PuppetParserHelper
     def self.compile_node_graph(content)
-      result = PuppetLanguageServerSidecar::Protocol::NodeGraph.new
+      result = PuppetLanguageServerSidecar::Protocol::Graph.new
 
       begin
-        # The fontsize is inserted in the puppet code.  Need to remove it so the client can render appropriately.  Need to
-        # set it to blank.  The graph label is set to editorservices so that we can do text replacement client side to inject the
-        # appropriate styling.
-        options = {
-          'fontsize' => '""',
-          'name'     => 'editorservices'
-        }
         node_graph = compile_to_pretty_relationship_graph(content)
         if node_graph.vertices.count.zero?
           result.set_error('There were no resources created in the node graph. Is there an include statement missing?')
-        else
-          result.dot_content = node_graph.to_dot(options)
+          return result
+        end
+
+        result.vertices = []
+        result.edges = []
+
+        node_graph.vertices.each do |vertex|
+          # TODO: more?
+          result.vertices << { label: vertex.to_s }
+        end
+
+        node_graph.edges.each do |edge|
+          # TODO: more?
+          result.edges << { source: edge.source.to_s, target: edge.target.to_s }
         end
       rescue StandardError => e
         result.set_error("Error while parsing the file. #{e}")

--- a/lib/puppet-languageserver-sidecar/sidecar_protocol_extensions.rb
+++ b/lib/puppet-languageserver-sidecar/sidecar_protocol_extensions.rb
@@ -4,10 +4,11 @@ require 'puppet-languageserver/sidecar_protocol'
 
 module PuppetLanguageServerSidecar
   module Protocol
-    class NodeGraph < PuppetLanguageServer::Sidecar::Protocol::NodeGraph
+    class Graph < PuppetLanguageServer::Sidecar::Protocol::Graph
       def set_error(message) # rubocop:disable Naming/AccessorMethodName
         self.error_content = message
-        self.dot_content = ''
+        self.vertices = nil
+        self.edges = nil
         self
       end
     end

--- a/lib/puppet-languageserver/message_handler.rb
+++ b/lib/puppet-languageserver/message_handler.rb
@@ -59,16 +59,17 @@ module PuppetLanguageServer
 
     def request_puppet_compilenodegraph(_, json_rpc_message)
       file_uri = json_rpc_message.params['external']
-      return LSP::CompileNodeGraphResponse.new('error' => 'Files of this type can not be used to create a node graph.') unless documents.document_type(file_uri) == :manifest
+      return LSP::GraphResponse.new('error' => 'Files of this type can not be used to create a node graph.') unless documents.document_type(file_uri) == :manifest
       content = documents.document(file_uri)
 
       begin
         node_graph = PuppetLanguageServer::PuppetHelper.get_node_graph(content, documents.store_root_path)
-        LSP::CompileNodeGraphResponse.new('dotContent' => node_graph.dot_content,
-                                          'error'      => node_graph.error_content)
+        LSP::GraphResponse.new('vertices' => node_graph.vertices,
+                               'edges'    => node_graph.edges,
+                               'error'    => node_graph.error_content)
       rescue StandardError => e
         PuppetLanguageServer.log_message(:error, "(puppet/compileNodeGraph) Error generating node graph. #{e}")
-        LSP::CompileNodeGraphResponse.new('error' => 'An internal error occured while generating the the node graph. Please see the debug log files for more information.')
+        LSP::GraphResponse.new('error' => 'An internal error occured while generating the the node graph. Please see the debug log files for more information.')
       end
     end
 

--- a/lib/puppet-languageserver/sidecar_protocol.rb
+++ b/lib/puppet-languageserver/sidecar_protocol.rb
@@ -141,20 +141,23 @@ module PuppetLanguageServer
         end
       end
 
-      class NodeGraph < BaseClass
-        attr_accessor :dot_content
+      class Graph < BaseClass
+        attr_accessor :vertices
+        attr_accessor :edges
         attr_accessor :error_content
 
         def to_json(*options)
           {
-            'dot_content'   => dot_content,
+            'vertices'      => vertices,
+            'edges'         => edges,
             'error_content' => error_content
           }.to_json(options)
         end
 
         def from_json!(json_string)
           obj = ::JSON.parse(json_string)
-          self.dot_content = obj['dot_content']
+          self.vertices = obj['vertices']
+          self.edges = obj['edges']
           self.error_content = obj['error_content']
           self
         end

--- a/lib/puppet-languageserver/sidecar_queue.rb
+++ b/lib/puppet-languageserver/sidecar_queue.rb
@@ -119,7 +119,7 @@ module PuppetLanguageServer
         PuppetLanguageServer::FacterHelper.assert_facts_loaded
 
       when 'node_graph'
-        return PuppetLanguageServer::Sidecar::Protocol::NodeGraph.new.from_json!(result)
+        return PuppetLanguageServer::Sidecar::Protocol::Graph.new.from_json!(result)
 
       when 'resource_list'
         return PuppetLanguageServer::Sidecar::Protocol::ResourceList.new.from_json!(result)

--- a/lib/puppet_languageserver_sidecar.rb
+++ b/lib/puppet_languageserver_sidecar.rb
@@ -307,7 +307,7 @@ module PuppetLanguageServerSidecar
 
     when 'node_graph'
       inject_workspace_as_module || inject_workspace_as_environment
-      result = PuppetLanguageServerSidecar::Protocol::NodeGraph.new
+      result = PuppetLanguageServerSidecar::Protocol::Graph.new
       if options[:action_parameters]['source'].nil?
         log_message(:error, 'Missing source action parameter')
         return result.set_error('Missing source action parameter')

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_puppetstrings/featureflag_puppetstrings_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_puppetstrings/featureflag_puppetstrings_spec.rb
@@ -287,10 +287,10 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings', :if => G
 
           result = run_sidecar(cmd_options.concat(['--action-parameters', action_params.to_json]))
 
-          deserial = PuppetLanguageServer::Sidecar::Protocol::NodeGraph.new()
+          deserial = PuppetLanguageServer::Sidecar::Protocol::Graph.new()
           expect { deserial.from_json!(result) }.to_not raise_error
 
-          expect(deserial.dot_content).to match(/Fixture\[test\]/)
+          expect(deserial.vertices[0]).to eq('label' => 'Fixture[test]')
           expect(deserial.error_content.to_s).to eq('')
         end
       end
@@ -471,10 +471,10 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings', :if => G
 
           result = run_sidecar(cmd_options.concat(['--action-parameters', action_params.to_json]))
 
-          deserial = PuppetLanguageServer::Sidecar::Protocol::NodeGraph.new()
+          deserial = PuppetLanguageServer::Sidecar::Protocol::Graph.new()
           expect { deserial.from_json!(result) }.to_not raise_error
 
-          expect(deserial.dot_content).to match(/Envtype\[test\]/)
+          expect(deserial.vertices[0]).to eq('label' => 'Envtype[test]')
           expect(deserial.error_content.to_s).to eq('')
         end
       end
@@ -644,10 +644,10 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings', :if => G
 
         result = run_sidecar(cmd_options.concat(['--action-parameters', action_params.to_json]))
 
-        deserial = PuppetLanguageServer::Sidecar::Protocol::NodeGraph.new()
+        deserial = PuppetLanguageServer::Sidecar::Protocol::Graph.new()
         expect { deserial.from_json!(result) }.to_not raise_error
 
-        expect(deserial.dot_content).to_not eq('')
+        expect(deserial.vertices.count).to be > 0
         expect(deserial.error_content.to_s).to eq('')
       end
     end

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/puppet-languageserver-sidecar_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/puppet-languageserver-sidecar_spec.rb
@@ -134,10 +134,10 @@ describe 'PuppetLanguageServerSidecar' do
 
           result = run_sidecar(cmd_options.concat(['--action-parameters', action_params.to_json]))
 
-          deserial = PuppetLanguageServer::Sidecar::Protocol::NodeGraph.new()
+          deserial = PuppetLanguageServer::Sidecar::Protocol::Graph.new()
           expect { deserial.from_json!(result) }.to_not raise_error
 
-          expect(deserial.dot_content).to match(/Fixture\[test\]/)
+          expect(deserial.vertices[0]).to eq('label' => 'Fixture[test]')
           expect(deserial.error_content.to_s).to eq('')
         end
       end
@@ -237,10 +237,10 @@ describe 'PuppetLanguageServerSidecar' do
 
           result = run_sidecar(cmd_options.concat(['--action-parameters', action_params.to_json]))
 
-          deserial = PuppetLanguageServer::Sidecar::Protocol::NodeGraph.new()
+          deserial = PuppetLanguageServer::Sidecar::Protocol::Graph.new()
           expect { deserial.from_json!(result) }.to_not raise_error
 
-          expect(deserial.dot_content).to match(/Envtype\[test\]/)
+          expect(deserial.vertices[0]).to eq('label' => 'Envtype[test]')
           expect(deserial.error_content.to_s).to eq('')
         end
       end
@@ -340,10 +340,10 @@ describe 'PuppetLanguageServerSidecar' do
 
         result = run_sidecar(cmd_options.concat(['--action-parameters', action_params.to_json]))
 
-        deserial = PuppetLanguageServer::Sidecar::Protocol::NodeGraph.new()
+        deserial = PuppetLanguageServer::Sidecar::Protocol::Graph.new()
         expect { deserial.from_json!(result) }.to_not raise_error
 
-        expect(deserial.dot_content).to_not eq('')
+        expect(deserial.vertices.count).to be > 0
         expect(deserial.error_content.to_s).to eq('')
       end
     end

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/puppet_parser_helper_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/puppet_parser_helper_spec.rb
@@ -24,14 +24,8 @@ describe 'PuppetLanguageServerSidecar::PuppetParserHelper' do
         result = subject.compile_node_graph(manifest)
         expect(result).to_not be_nil
 
-        # Make sure it's a DOT graph file
-        expect(result.dot_content).to match(/digraph/)
         # Make sure the resource is there
-        expect(result.dot_content).to match(/User\[test\]/)
-        # Make sure the fontsize is set to empty
-        expect(result.dot_content).to match(/fontsize = \"\"/)
-        # Make sure the label is editorservices
-        expect(result.dot_content).to match(/label = \"editorservices\"/)
+        expect(deserial.vertices[0]).to eq('label' => 'User[test]')
         # Expect no errors
         expect(result.error_content.to_s).to eq('')
       end
@@ -43,7 +37,8 @@ describe 'PuppetLanguageServerSidecar::PuppetParserHelper' do
       it 'should compile with an error' do
         result = subject.compile_node_graph(manifest)
         expect(result).to_not be_nil
-        expect(result.dot_content).to eq("")
+        expect(result.edges).to be_nil
+        expect(result.vertices).to be_nil
         expect(result.error_content).to match(/no resources created in the node graph/)
       end
     end
@@ -54,7 +49,8 @@ describe 'PuppetLanguageServerSidecar::PuppetParserHelper' do
       it 'should compile with an error' do
         result = subject.compile_node_graph(manifest)
         expect(result).to_not be_nil
-        expect(result.dot_content).to eq("")
+        expect(result.edges).to be_nil
+        expect(result.vertices).to be_nil
         expect(result.error_content).to match(/Error while parsing the file./)
       end
     end

--- a/spec/languageserver-sidecar/unit/puppet-languageserver-sidecar/sidecar_protocol_extensions_spec.rb
+++ b/spec/languageserver-sidecar/unit/puppet-languageserver-sidecar/sidecar_protocol_extensions_spec.rb
@@ -10,15 +10,16 @@ describe 'PuppetLanguageServerSidecar::Protocol' do
     end
   end
 
-  describe 'NodeGraph' do
-    let(:subject_klass) { PuppetLanguageServerSidecar::Protocol::NodeGraph }
+  describe 'Graph' do
+    let(:subject_klass) { PuppetLanguageServerSidecar::Protocol::Graph }
     let(:subject) { subject_klass.new }
 
     it "instance should respond to set_error" do
       expect(subject).to respond_to(:set_error)
       result = subject.set_error('test_error')
-      expect(result.dot_content).to eq('')
       expect(result.error_content).to eq('test_error')
+      expect(result.vertices).to be_nil
+      expect(result.edges).to be_nil
     end
   end
 

--- a/spec/languageserver/unit/puppet-languageserver/message_handler_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/message_handler_spec.rb
@@ -236,7 +236,6 @@ describe 'PuppetLanguageServer::MessageHandler' do
       let(:request_rpc_method) { 'puppet/compileNodeGraph' }
       let(:file_uri) { MANIFEST_FILENAME }
       let(:file_content) { 'some file content' }
-      let(:dot_content) { 'some graph content' }
       let(:request_params) {{
         'external' => file_uri
       }}
@@ -254,15 +253,16 @@ describe 'PuppetLanguageServer::MessageHandler' do
           expect(subject.request_puppet_compilenodegraph(connection_id, request_message)).to have_attributes(:error => /Files of this type/)
         end
 
-        it 'should not reply with dotContent' do
-          expect(subject.request_puppet_compilenodegraph(connection_id, request_message)).to_not have_attributes(:dotContent => /.+/)
+        it 'should not reply with graph content' do
+          expect(subject.request_puppet_compilenodegraph(connection_id, request_message)).to have_attributes(:edges => nil, :vertices => nil)
         end
       end
 
       context 'and an error during generation of the node graph' do
         let(:mock_return) {
-          value = PuppetLanguageServer::Sidecar::Protocol::NodeGraph.new()
-          value.dot_content = ''
+          value = PuppetLanguageServer::Sidecar::Protocol::Graph.new()
+          value.edges = nil
+          value.vertices = nil
           value.error_content = 'MockError'
           value
         }
@@ -275,15 +275,16 @@ describe 'PuppetLanguageServer::MessageHandler' do
           expect(subject.request_puppet_compilenodegraph(connection_id, request_message)).to have_attributes(:error => /MockError/)
         end
 
-        it 'should not reply with dotContent' do
-          expect(subject.request_puppet_compilenodegraph(connection_id, request_message)).to have_attributes(:dotContent => '')
+        it 'should not reply with graph content' do
+          expect(subject.request_puppet_compilenodegraph(connection_id, request_message)).to have_attributes(:edges => nil, :vertices => nil)
         end
       end
 
       context 'and successfully generate the node graph' do
         let(:mock_return) {
-          value = PuppetLanguageServer::Sidecar::Protocol::NodeGraph.new()
-          value.dot_content = 'success'
+          value = PuppetLanguageServer::Sidecar::Protocol::Graph.new()
+          value.edges = []
+          value.vertices = []
           value.error_content = ''
           value
         }
@@ -293,7 +294,7 @@ describe 'PuppetLanguageServer::MessageHandler' do
         end
 
         it 'should reply with dotContent' do
-          expect(subject.request_puppet_compilenodegraph(connection_id, request_message)).to have_attributes(:dotContent => /success/)
+          expect(subject.request_puppet_compilenodegraph(connection_id, request_message)).to have_attributes(:edges => [], :vertices => [])
         end
 
         it 'should not reply with error' do

--- a/spec/languageserver/unit/puppet-languageserver/sidecar_protocol_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/sidecar_protocol_spec.rb
@@ -71,7 +71,7 @@ describe 'PuppetLanguageServer::Sidecar::Protocol' do
 
   basepuppetobject_properties = [:key, :calling_source, :source, :line, :char, :length]
   fact_properties = [:value]
-  nodegraph_properties = [:dot_content, :error_content]
+  graph_properties = [:edges, :vertices, :error_content]
   puppetclass_properties = [:doc, :parameters]
   puppetdatatype_properties = [:doc, :alias_of, :attributes, :is_type_alias]
   puppetdatatypeattribute_properties = [:key, :doc, :default_value, :types]
@@ -179,11 +179,12 @@ describe 'PuppetLanguageServer::Sidecar::Protocol' do
     end
   end
 
-  describe 'NodeGraph' do
-    let(:subject_klass) { PuppetLanguageServer::Sidecar::Protocol::NodeGraph }
+  describe 'Graph' do
+    let(:subject_klass) { PuppetLanguageServer::Sidecar::Protocol::Graph }
     let(:subject) {
       value = subject_klass.new
-      value.dot_content = 'dot_content_' + rand(1000).to_s
+      value.edges = []
+      value.vertices = []
       value.error_content = 'error_content_' + rand(1000).to_s
       value
     }
@@ -191,9 +192,8 @@ describe 'PuppetLanguageServer::Sidecar::Protocol' do
     it_should_behave_like 'a base Sidecar Protocol object'
 
     describe '#from_json!' do
-      nodegraph_properties.each do |testcase|
+      graph_properties.each do |testcase|
         it "should deserialize a serialized #{testcase} value" do
-          #require 'pry'; binding.pry
           serial = subject.to_json
           deserial = subject_klass.new.from_json!(serial)
 


### PR DESCRIPTION
Fixes #221 

TODO

- [ ] Need to complete creating the graph
- [x] Once the edge/vertices are calculated update the tests that look for content.
- [x] Remove all references to the old NodeGraph response.

---

Previously the NodeGraph response was entirely DOT language centric however the
LSP should really be returning structured data which the client can deal with
as it is trivial to convert it to DOT file, or whatever the visualisation
library requires.  This commit:

* Changes the response object to GraphResponse which has an edges and vertices
  array of hashes.

* Updates all of the the puppet_compilenodegraph LSP method to use the new
  GraphResponse type.

* Updates all of the tests for the new response object type.