### PR TITLE
(GH-207) Allow Qualified Resource Names in hover provider

### DIFF
--- a/spec/languageserver/integration/puppet-languageserver/manifest/hover_provider_spec.rb
+++ b/spec/languageserver/integration/puppet-languageserver/manifest/hover_provider_spec.rb
@@ -299,12 +299,25 @@ mock_workspace_class { 'Dee':
   attr_name1 => 'string1',
   attr_name2 => 'string1',
 }
+
+::mock_workspace_class { 'Dah': }
 EOT
       }
 
       describe 'when cursor is on the resource type name' do
         let(:line_num) { 0 }
         let(:char_num) { 3 }
+
+        it 'should return resource description' do
+          result = subject.resolve(content, line_num, char_num)
+
+          expect(result.contents).to start_with("**mock_workspace_class** Resource\n")
+        end
+      end
+
+      describe 'when cursor is on the top-scoped resource type name' do
+        let(:line_num) { 5 }
+        let(:char_num) { 5 }
 
         it 'should return resource description' do
           result = subject.resolve(content, line_num, char_num)


### PR DESCRIPTION
Fixes #207 

Previously the hover provider ignored qualified names like '::foo::bar`.  This
commit updates the Hover Provider to allow QualifedNames but use what the name
is of during processing.  This commit also adds tests for this scenario.
