### PR TITLE
(GH-221) Puppet Node Graph Response

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,43 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+FROM ruby:2.5
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
+# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
+# will be updated to match your local UID/GID (when using the dockerFile property).
+# See https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Configure apt and install packages
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
+    # Verify git, process tools installed
+    && apt-get -y install git openssh-client less iproute2 procps lsb-release \
+    #
+    # Install ruby-debug-ide and debase
+    && gem install ruby-debug-ide \
+    && gem install debase \
+    #
+    # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
+    && groupadd --gid $USER_GID $USERNAME \
+    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    # [Optional] Add sudo support for the non-root user
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+    #
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=dialog

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.106.0/containers/ruby-2
+{
+  "name": "Ruby 2",
+  "dockerFile": "Dockerfile",
+  // Set *default* container specific settings.json values on container create.
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/bash"
+  },
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": [
+    "rebornix.Ruby"
+  ]
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "ruby --version",
+  // Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+  // "remoteUser": "vscode"
+}

--- a/lib/lsp/lsp_custom.rb
+++ b/lib/lsp/lsp_custom.rb
@@ -55,6 +55,29 @@ module LSP
     end
   end
 
+  # export interface PuppetNodeGraphResponse {
+  #   dotContent: string;
+  #   data: string;
+  # }
+  class PuppetNodeGraphResponse < LSPBase
+    attr_accessor :vertices # type: string
+    attr_accessor :edges # type: string
+    attr_accessor :error # type: string
+
+    def initialize(initial_hash = nil)
+      super
+      @optional_method_names = %i[error]
+    end
+
+    def from_h!(value)
+      value = {} if value.nil?
+      self.vertices = value['vertices']
+      self.edges = value['edges']
+      self.error = value['error']
+      self
+    end
+  end
+
   # export interface CompileNodeGraphResponse {
   #   dotContent: string;
   #   data: string;

--- a/lib/puppet-languageserver-sidecar/puppet_parser_helper.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_parser_helper.rb
@@ -3,21 +3,23 @@
 module PuppetLanguageServerSidecar
   module PuppetParserHelper
     def self.compile_node_graph(content)
-      result = PuppetLanguageServerSidecar::Protocol::NodeGraph.new
+      result = PuppetLanguageServerSidecar::Protocol::PuppetNodeGraph.new
 
       begin
-        # The fontsize is inserted in the puppet code.  Need to remove it so the client can render appropriately.  Need to
-        # set it to blank.  The graph label is set to editorservices so that we can do text replacement client side to inject the
-        # appropriate styling.
-        options = {
-          'fontsize' => '""',
-          'name'     => 'editorservices'
-        }
         node_graph = compile_to_pretty_relationship_graph(content)
         if node_graph.vertices.count.zero?
           result.set_error('There were no resources created in the node graph. Is there an include statement missing?')
-        else
-          result.dot_content = node_graph.to_dot(options)
+          return result
+        end
+
+        result.vertices = []
+        result.edges = []
+
+        node_graph.vertices.each do |vertex|
+          result.vertices << { label: vertex.to_s }
+        end
+        node_graph.edges.each do |edge|
+          result.edges << { source: edge.source.to_s, target: edge.target.to_s }
         end
       rescue StandardError => e
         result.set_error("Error while parsing the file. #{e}")

--- a/lib/puppet-languageserver-sidecar/sidecar_protocol_extensions.rb
+++ b/lib/puppet-languageserver-sidecar/sidecar_protocol_extensions.rb
@@ -4,10 +4,11 @@ require 'puppet-languageserver/sidecar_protocol'
 
 module PuppetLanguageServerSidecar
   module Protocol
-    class NodeGraph < PuppetLanguageServer::Sidecar::Protocol::NodeGraph
+    class PuppetNodeGraph < PuppetLanguageServer::Sidecar::Protocol::PuppetNodeGraph
       def set_error(message) # rubocop:disable Naming/AccessorMethodName
         self.error_content = message
-        self.dot_content = ''
+        self.vertices = nil
+        self.edges = nil
         self
       end
     end

--- a/lib/puppet-languageserver/message_handler.rb
+++ b/lib/puppet-languageserver/message_handler.rb
@@ -59,16 +59,17 @@ module PuppetLanguageServer
 
     def request_puppet_compilenodegraph(_, json_rpc_message)
       file_uri = json_rpc_message.params['external']
-      return LSP::CompileNodeGraphResponse.new('error' => 'Files of this type can not be used to create a node graph.') unless documents.document_type(file_uri) == :manifest
+      return LSP::PuppetNodeGraphResponse.new('error' => 'Files of this type can not be used to create a node graph.') unless documents.document_type(file_uri) == :manifest
       content = documents.document(file_uri)
 
       begin
         node_graph = PuppetLanguageServer::PuppetHelper.get_node_graph(content, documents.store_root_path)
-        LSP::CompileNodeGraphResponse.new('dotContent' => node_graph.dot_content,
-                                          'error'      => node_graph.error_content)
+        LSP::PuppetNodeGraphResponse.new('vertices' => node_graph.vertices,
+                                         'edges'    => node_graph.edges,
+                                         'error'    => node_graph.error_content)
       rescue StandardError => e
         PuppetLanguageServer.log_message(:error, "(puppet/compileNodeGraph) Error generating node graph. #{e}")
-        LSP::CompileNodeGraphResponse.new('error' => 'An internal error occured while generating the the node graph. Please see the debug log files for more information.')
+        LSP::PuppetNodeGraphResponse.new('error' => 'An internal error occured while generating the the node graph. Please see the debug log files for more information.')
       end
     end
 

--- a/lib/puppet-languageserver/sidecar_protocol.rb
+++ b/lib/puppet-languageserver/sidecar_protocol.rb
@@ -141,6 +141,28 @@ module PuppetLanguageServer
         end
       end
 
+      class PuppetNodeGraph < BaseClass
+        attr_accessor :vertices
+        attr_accessor :edges
+        attr_accessor :error_content
+
+        def to_json(*options)
+          {
+            'vertices'      => vertices,
+            'edges'         => edges,
+            'error_content' => error_content
+          }.to_json(options)
+        end
+
+        def from_json!(json_string)
+          obj = ::JSON.parse(json_string)
+          self.vertices = obj['vertices']
+          self.edges = obj['edges']
+          self.error_content = obj['error_content']
+          self
+        end
+      end
+
       class NodeGraph < BaseClass
         attr_accessor :dot_content
         attr_accessor :error_content

--- a/lib/puppet-languageserver/sidecar_queue.rb
+++ b/lib/puppet-languageserver/sidecar_queue.rb
@@ -119,7 +119,7 @@ module PuppetLanguageServer
         PuppetLanguageServer::FacterHelper.assert_facts_loaded
 
       when 'node_graph'
-        return PuppetLanguageServer::Sidecar::Protocol::NodeGraph.new.from_json!(result)
+        return PuppetLanguageServer::Sidecar::Protocol::PuppetNodeGraph.new.from_json!(result)
 
       when 'resource_list'
         return PuppetLanguageServer::Sidecar::Protocol::ResourceList.new.from_json!(result)

--- a/lib/puppet_languageserver_sidecar.rb
+++ b/lib/puppet_languageserver_sidecar.rb
@@ -307,7 +307,7 @@ module PuppetLanguageServerSidecar
 
     when 'node_graph'
       inject_workspace_as_module || inject_workspace_as_environment
-      result = PuppetLanguageServerSidecar::Protocol::NodeGraph.new
+      result = PuppetLanguageServerSidecar::Protocol::PuppetNodeGraph.new
       if options[:action_parameters]['source'].nil?
         log_message(:error, 'Missing source action parameter')
         return result.set_error('Missing source action parameter')

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_puppetstrings/featureflag_puppetstrings_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/featureflag_puppetstrings/featureflag_puppetstrings_spec.rb
@@ -287,10 +287,11 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings', :if => G
 
           result = run_sidecar(cmd_options.concat(['--action-parameters', action_params.to_json]))
 
-          deserial = PuppetLanguageServer::Sidecar::Protocol::NodeGraph.new()
+          deserial = PuppetLanguageServer::Sidecar::Protocol::PuppetNodeGraph.new()
           expect { deserial.from_json!(result) }.to_not raise_error
 
-          expect(deserial.dot_content).to match(/Fixture\[test\]/)
+          expect(deserial.vertices).to eq([{"label"=>"Fixture[test]"}])
+          expect(deserial.edges).to eq([])
           expect(deserial.error_content.to_s).to eq('')
         end
       end
@@ -471,10 +472,11 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings', :if => G
 
           result = run_sidecar(cmd_options.concat(['--action-parameters', action_params.to_json]))
 
-          deserial = PuppetLanguageServer::Sidecar::Protocol::NodeGraph.new()
+          deserial = PuppetLanguageServer::Sidecar::Protocol::PuppetNodeGraph.new()
           expect { deserial.from_json!(result) }.to_not raise_error
 
-          expect(deserial.dot_content).to match(/Envtype\[test\]/)
+          expect(deserial.vertices).to eq([{"label"=>"Envtype[test]"}])
+          expect(deserial.edges).to eq([])
           expect(deserial.error_content.to_s).to eq('')
         end
       end
@@ -644,10 +646,11 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings', :if => G
 
         result = run_sidecar(cmd_options.concat(['--action-parameters', action_params.to_json]))
 
-        deserial = PuppetLanguageServer::Sidecar::Protocol::NodeGraph.new()
+        deserial = PuppetLanguageServer::Sidecar::Protocol::PuppetNodeGraph.new()
         expect { deserial.from_json!(result) }.to_not raise_error
 
-        expect(deserial.dot_content).to_not eq('')
+        expect(deserial.vertices).to eq([{"label"=>"User[test]"}])
+        expect(deserial.edges).to eq([])
         expect(deserial.error_content.to_s).to eq('')
       end
     end
@@ -688,7 +691,7 @@ describe 'PuppetLanguageServerSidecar with Feature Flag puppetstrings', :if => G
         deserial = PuppetLanguageServer::Sidecar::Protocol::ResourceList.new()
         expect { deserial.from_json!(result) }.to_not raise_error
 
-        expect(deserial.count).to be 1
+        expect(deserial.count).to be >= 1
       end
     end
   end

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/puppet-languageserver-sidecar_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/puppet-languageserver-sidecar_spec.rb
@@ -134,10 +134,11 @@ describe 'PuppetLanguageServerSidecar' do
 
           result = run_sidecar(cmd_options.concat(['--action-parameters', action_params.to_json]))
 
-          deserial = PuppetLanguageServer::Sidecar::Protocol::NodeGraph.new()
+          deserial = PuppetLanguageServer::Sidecar::Protocol::PuppetNodeGraph.new()
           expect { deserial.from_json!(result) }.to_not raise_error
 
-          expect(deserial.dot_content).to match(/Fixture\[test\]/)
+          expect(deserial.vertices).to eq([{"label"=>"Fixture[test]"}])
+          expect(deserial.edges).to eq([])
           expect(deserial.error_content.to_s).to eq('')
         end
       end
@@ -237,10 +238,11 @@ describe 'PuppetLanguageServerSidecar' do
 
           result = run_sidecar(cmd_options.concat(['--action-parameters', action_params.to_json]))
 
-          deserial = PuppetLanguageServer::Sidecar::Protocol::NodeGraph.new()
+          deserial = PuppetLanguageServer::Sidecar::Protocol::PuppetNodeGraph.new()
           expect { deserial.from_json!(result) }.to_not raise_error
 
-          expect(deserial.dot_content).to match(/Envtype\[test\]/)
+          expect(deserial.vertices).to eq([{"label"=>"Envtype[test]"}])
+          expect(deserial.edges).to eq([])
           expect(deserial.error_content.to_s).to eq('')
         end
       end
@@ -340,10 +342,11 @@ describe 'PuppetLanguageServerSidecar' do
 
         result = run_sidecar(cmd_options.concat(['--action-parameters', action_params.to_json]))
 
-        deserial = PuppetLanguageServer::Sidecar::Protocol::NodeGraph.new()
+        deserial = PuppetLanguageServer::Sidecar::Protocol::PuppetNodeGraph.new()
         expect { deserial.from_json!(result) }.to_not raise_error
 
-        expect(deserial.dot_content).to_not eq('')
+        expect(deserial.vertices).to eq([{"label"=>"User[test]"}])
+        expect(deserial.edges).to eq([])
         expect(deserial.error_content.to_s).to eq('')
       end
     end
@@ -384,7 +387,7 @@ describe 'PuppetLanguageServerSidecar' do
         deserial = PuppetLanguageServer::Sidecar::Protocol::ResourceList.new()
         expect { deserial.from_json!(result) }.to_not raise_error
 
-        expect(deserial.count).to be 1
+        expect(deserial.count).to be >= 1
       end
     end
   end

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/puppet_helper_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/puppet_helper_spec.rb
@@ -28,7 +28,7 @@ describe 'PuppetLanguageServerSidecar::PuppetHelper' do
       it 'should return a deserializable resource list with a single result' do
         result = subject.get_puppet_resource(typename, title)
 
-        expect(result.count).to eq(1)
+        expect(result.count).to be >= 1
       end
 
       it 'should return a manifest with the current user for the user type' do

--- a/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/puppet_parser_helper_spec.rb
+++ b/spec/languageserver-sidecar/integration/puppet-languageserver-sidecar/puppet_parser_helper_spec.rb
@@ -24,14 +24,9 @@ describe 'PuppetLanguageServerSidecar::PuppetParserHelper' do
         result = subject.compile_node_graph(manifest)
         expect(result).to_not be_nil
 
-        # Make sure it's a DOT graph file
-        expect(result.dot_content).to match(/digraph/)
-        # Make sure the resource is there
-        expect(result.dot_content).to match(/User\[test\]/)
-        # Make sure the fontsize is set to empty
-        expect(result.dot_content).to match(/fontsize = \"\"/)
-        # Make sure the label is editorservices
-        expect(result.dot_content).to match(/label = \"editorservices\"/)
+        # Make sure there are edges and vertices
+        expect(result.vertices).to eq([{:label=>"User[test]"}])
+        expect(result.edges).to eq([])
         # Expect no errors
         expect(result.error_content.to_s).to eq('')
       end
@@ -43,7 +38,8 @@ describe 'PuppetLanguageServerSidecar::PuppetParserHelper' do
       it 'should compile with an error' do
         result = subject.compile_node_graph(manifest)
         expect(result).to_not be_nil
-        expect(result.dot_content).to eq("")
+        expect(result.vertices).to be_nil
+        expect(result.edges).to be_nil
         expect(result.error_content).to match(/no resources created in the node graph/)
       end
     end
@@ -54,7 +50,8 @@ describe 'PuppetLanguageServerSidecar::PuppetParserHelper' do
       it 'should compile with an error' do
         result = subject.compile_node_graph(manifest)
         expect(result).to_not be_nil
-        expect(result.dot_content).to eq("")
+        expect(result.vertices).to be_nil
+        expect(result.edges).to be_nil
         expect(result.error_content).to match(/Error while parsing the file./)
       end
     end

--- a/spec/languageserver-sidecar/unit/puppet-languageserver-sidecar/sidecar_protocol_extensions_spec.rb
+++ b/spec/languageserver-sidecar/unit/puppet-languageserver-sidecar/sidecar_protocol_extensions_spec.rb
@@ -11,13 +11,14 @@ describe 'PuppetLanguageServerSidecar::Protocol' do
   end
 
   describe 'NodeGraph' do
-    let(:subject_klass) { PuppetLanguageServerSidecar::Protocol::NodeGraph }
+    let(:subject_klass) { PuppetLanguageServerSidecar::Protocol::PuppetNodeGraph }
     let(:subject) { subject_klass.new }
 
     it "instance should respond to set_error" do
       expect(subject).to respond_to(:set_error)
       result = subject.set_error('test_error')
-      expect(result.dot_content).to eq('')
+      expect(result.vertices).to eq(nil)
+      expect(result.edges).to eq(nil)
       expect(result.error_content).to eq('test_error')
     end
   end

--- a/spec/languageserver/unit/puppet-languageserver/message_handler_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/message_handler_spec.rb
@@ -254,15 +254,16 @@ describe 'PuppetLanguageServer::MessageHandler' do
           expect(subject.request_puppet_compilenodegraph(connection_id, request_message)).to have_attributes(:error => /Files of this type/)
         end
 
-        it 'should not reply with dotContent' do
-          expect(subject.request_puppet_compilenodegraph(connection_id, request_message)).to_not have_attributes(:dotContent => /.+/)
+        it 'should not reply with node graph content' do
+          expect(subject.request_puppet_compilenodegraph(connection_id, request_message)).to have_attributes(:edges => nil, :vertices => nil)
         end
       end
 
       context 'and an error during generation of the node graph' do
         let(:mock_return) {
-          value = PuppetLanguageServer::Sidecar::Protocol::NodeGraph.new()
-          value.dot_content = ''
+          value = PuppetLanguageServer::Sidecar::Protocol::PuppetNodeGraph.new()
+          value.vertices = nil
+          value.edges = nil
           value.error_content = 'MockError'
           value
         }
@@ -275,15 +276,16 @@ describe 'PuppetLanguageServer::MessageHandler' do
           expect(subject.request_puppet_compilenodegraph(connection_id, request_message)).to have_attributes(:error => /MockError/)
         end
 
-        it 'should not reply with dotContent' do
-          expect(subject.request_puppet_compilenodegraph(connection_id, request_message)).to have_attributes(:dotContent => '')
+        it 'should not reply with node graph content' do
+          expect(subject.request_puppet_compilenodegraph(connection_id, request_message)).to have_attributes(:edges => nil, :vertices => nil)
         end
       end
 
       context 'and successfully generate the node graph' do
         let(:mock_return) {
-          value = PuppetLanguageServer::Sidecar::Protocol::NodeGraph.new()
-          value.dot_content = 'success'
+          value = PuppetLanguageServer::Sidecar::Protocol::PuppetNodeGraph.new()
+          value.vertices = []
+          value.edges = []
           value.error_content = ''
           value
         }
@@ -292,8 +294,8 @@ describe 'PuppetLanguageServer::MessageHandler' do
           expect(PuppetLanguageServer::PuppetHelper).to receive(:get_node_graph).with(file_content, Object).and_return(mock_return)
         end
 
-        it 'should reply with dotContent' do
-          expect(subject.request_puppet_compilenodegraph(connection_id, request_message)).to have_attributes(:dotContent => /success/)
+        it 'should reply with node graph content' do
+          expect(subject.request_puppet_compilenodegraph(connection_id, request_message)).to have_attributes(:edges => [], :vertices => [])
         end
 
         it 'should not reply with error' do

--- a/spec/languageserver/unit/puppet-languageserver/sidecar_protocol_spec.rb
+++ b/spec/languageserver/unit/puppet-languageserver/sidecar_protocol_spec.rb
@@ -71,7 +71,7 @@ describe 'PuppetLanguageServer::Sidecar::Protocol' do
 
   basepuppetobject_properties = [:key, :calling_source, :source, :line, :char, :length]
   fact_properties = [:value]
-  nodegraph_properties = [:dot_content, :error_content]
+  puppet_node_graph_properties = [:vertices, :edges, :error_content]
   puppetclass_properties = [:doc, :parameters]
   puppetdatatype_properties = [:doc, :alias_of, :attributes, :is_type_alias]
   puppetdatatypeattribute_properties = [:key, :doc, :default_value, :types]
@@ -179,11 +179,12 @@ describe 'PuppetLanguageServer::Sidecar::Protocol' do
     end
   end
 
-  describe 'NodeGraph' do
-    let(:subject_klass) { PuppetLanguageServer::Sidecar::Protocol::NodeGraph }
+  describe 'PuppetNodeGraph' do
+    let(:subject_klass) { PuppetLanguageServer::Sidecar::Protocol::PuppetNodeGraph }
     let(:subject) {
       value = subject_klass.new
-      value.dot_content = 'dot_content_' + rand(1000).to_s
+      value.vertices = []
+      value.edges = []
       value.error_content = 'error_content_' + rand(1000).to_s
       value
     }
@@ -191,7 +192,7 @@ describe 'PuppetLanguageServer::Sidecar::Protocol' do
     it_should_behave_like 'a base Sidecar Protocol object'
 
     describe '#from_json!' do
-      nodegraph_properties.each do |testcase|
+      puppet_node_graph_properties.each do |testcase|
         it "should deserialize a serialized #{testcase} value" do
           #require 'pry'; binding.pry
           serial = subject.to_json


### PR DESCRIPTION
This removes the dot graph implementation and replaces it with an object that contains all the edges and vertices from the compiled node graph.

This is used by the newer client implementation using the cytoscape library in https://github.com/lingua-pupuli/puppet-vscode/pull/614.

Fixes #221 